### PR TITLE
Combine sonar plugin configurations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          JAVA_TOOL_OPTIONS: "-Djavax.net.ssl.trustStore=${{ env.JAVA_HOME }}/lib/security/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
         run: ./gradlew sonar --parallel --build-cache --stacktrace --info
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.ktfmt)
-    alias(libs.plugins.sonar)
     id("jacoco")
 }
 
@@ -88,21 +87,6 @@ android {
         java.setSrcDirs(emptyList<File>())
         res.setSrcDirs(emptyList<File>())
         resources.setSrcDirs(emptyList<File>())
-    }
-}
-
-sonar {
-    properties {
-        property("sonar.projectKey", "StudentConnect-SwEnt_StudentConnect")
-        property("sonar.projectName", "StudentConnect")
-        property("sonar.organization", "studentconnect-swent")
-        property("sonar.host.url", "https://sonarcloud.io")
-        // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.
-        property("sonar.junit.reportPaths", "${project.layout.buildDirectory.get()}/test-results/testDebugunitTest/")
-        // Paths to xml files with Android Lint issues. If the main flavor is changed, this file will have to be changed too.
-        property("sonar.androidLint.reportPaths", "${project.layout.buildDirectory.get()}/reports/lint-results-debug.xml")
-        // Paths to JaCoCo XML coverage report files.
-        property("sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory.get()}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,17 @@ plugins {
 }
 
 sonar {
-  properties {
-    property("sonar.projectKey", "StudentConnect-SwEnt_StudentConnect")
-    property("sonar.organization", "studentconnect-swent")
-  }
+    properties {
+        property("sonar.projectKey", "StudentConnect-SwEnt_StudentConnect")
+        property("sonar.projectName", "StudentConnect")
+        property("sonar.organization", "studentconnect-swent")
+        property("sonar.host.url", "https://sonarcloud.io")
+        // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.
+        property("sonar.junit.reportPaths", "${project.layout.buildDirectory.get()}/test-results/testDebugunitTest/")
+        // Paths to xml files with Android Lint issues. If the main flavor is changed, this file will have to be changed too.
+        property("sonar.androidLint.reportPaths", "${project.layout.buildDirectory.get()}/reports/lint-results-debug.xml")
+        // Paths to JaCoCo XML coverage report files.
+        property("sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory.get()}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
+    }
 }
+


### PR DESCRIPTION
Move the sonar plugin configurations in `app/build.gradle.kts` to `build.gradle.kts` to keep the configs together.