### PR TITLE
Add version controlled git hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/sh
+echo "[pre-commit] Checking formatting with ktfmt..."
+
+./gradlew ktfmtCheck --quiet
+RESULT=$?
+
+if [ $RESULT -ne 0 ]; then
+  echo "[pre-commit] Some files are not properly formatted."
+  exit 1
+fi
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -16,3 +16,19 @@ Many students in Switzerland, especially newcomers, face difficulties building s
 
 View the design on [Figma](https://www.figma.com/design/o08ZOLr2SxUiip650CyqbW/App?m=auto&t=pcxsobh043Boudab-1)
 
+## Development Setup
+
+After cloning the repository, you need to configure Git to use the version-controlled hooks.
+
+### macOS / Linux / Windows (Git Bash)
+
+```sh
+./scripts/setup-hooks.sh
+```
+
+### Windows (PowerShell)
+
+```sh
+./scripts/setup-hooks.ps1
+```
+

--- a/scripts/setup-hooks.ps1
+++ b/scripts/setup-hooks.ps1
@@ -1,0 +1,9 @@
+# Configures git to use the version-controlled hooks in .githooks/
+
+Write-Output "Setting up Git hooks..."
+
+# Configure git to use .githooks
+git config core.hooksPath .githooks
+
+Write-Output "Git hooks configured to use .githooks/"
+

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Configures git to use the version-controlled hooks in .githooks/
+
+set -e
+
+echo "Setting up Git hooks..."
+
+# Configure git to use .githooks
+git config core.hooksPath .githooks
+
+echo "Git hooks configured to use .githooks/"
+


### PR DESCRIPTION
Add version controlled git hooks in the `.githooks` directory as well as setup scripts for macOS/Linux/Git Bash and Windows Powershell in `scripts/setup-hooks.sh` and `scripts/setup-hooks.ps1`.

New contributors should run the `./scripts/setup-hooks.sh` command (or the PowerShell version) when first cloning the repo to use those git hooks. This makes sure everyone has the same checks running with minimal effort (instead of everyone manually copy pasting the hooks into `.git/hooks`).

Also included instructions in the `README.md` to run those scripts when first cloning the repo.

A pre-commit hook checking code formatting using `ktfmtCheck` was added to reduce `CI` failures due to incorrectly formatted code.

