### PR TITLE
Implement backend for activities

### DIFF
--- a/app/src/main/java/com/github/se/studentconnect/model/User.kt
+++ b/app/src/main/java/com/github/se/studentconnect/model/User.kt
@@ -1,5 +1,7 @@
 package com.github.se.studentconnect.model
 
+import com.github.se.studentconnect.model.event.Event
+
 /**
  * Represents a User in the StudentConnect application.
  *
@@ -24,7 +26,8 @@ data class User(
     val profilePictureUrl: String? = null, // optional
     val bio: String? = null, // optional
     val createdAt: Long = System.currentTimeMillis(),
-    val updatedAt: Long = System.currentTimeMillis()
+    val updatedAt: Long = System.currentTimeMillis(),
+    val joinedEvents: List<Event> = emptyList(),
 ) {
   init {
     require(userId.isNotBlank()) { "User ID cannot be blank" }
@@ -123,7 +126,8 @@ data class User(
               is UpdateValue.SetValue -> bio.value
               else -> this.bio
             },
-        updatedAt = System.currentTimeMillis())
+        updatedAt = System.currentTimeMillis(),
+        joinedEvents = this.joinedEvents)
   }
 
   /**
@@ -142,7 +146,8 @@ data class User(
         "profilePictureUrl" to profilePictureUrl,
         "bio" to bio,
         "createdAt" to createdAt,
-        "updatedAt" to updatedAt)
+        "updatedAt" to updatedAt,
+        "joinedEvents" to joinedEvents.map { it.uid })
   }
 
   companion object {

--- a/app/src/main/java/com/github/se/studentconnect/model/event/EventRepositoryLocal.kt
+++ b/app/src/main/java/com/github/se/studentconnect/model/event/EventRepositoryLocal.kt
@@ -1,0 +1,99 @@
+// Portions of this code were generated with the help of Gemini
+package com.github.se.studentconnect.model.event
+
+import java.util.UUID
+
+/**
+ * Represents a repository that manages a local list of events. This class is intended for testing
+ * and development purposes.
+ */
+class EventRepositoryLocal : EventRepository {
+  private val events = mutableListOf<Event>()
+  private val participantsByEvent = mutableMapOf<String, MutableList<EventParticipant>>()
+
+  override fun getNewUid(): String {
+    return UUID.randomUUID().toString()
+  }
+
+  override suspend fun getAllVisibleEvents(): List<Event> {
+    return events.toList()
+  }
+
+  override suspend fun getAllVisibleEventsSatisfying(predicate: (Event) -> Boolean): List<Event> {
+    return events.filter(predicate)
+  }
+
+  override suspend fun getEvent(eventUid: String): Event {
+    return events.find { it.uid == eventUid }
+        ?: throw NoSuchElementException("Event with UID $eventUid not found.")
+  }
+
+  override suspend fun getEventParticipants(eventUid: String): List<EventParticipant> {
+    return participantsByEvent[eventUid]?.toList() ?: emptyList()
+  }
+
+  /** Correctly implemented function to get events a user is attending. */
+  override suspend fun getEventsAttendedByUser(userUid: String): List<Event> {
+    // TODO filter based on if the currently logged in user can see the event or not; for now, gets
+    //  all events
+    return events
+  }
+
+  override suspend fun addEvent(event: Event) {
+    if (events.any { it.uid == event.uid }) {
+      // This throws IllegalArgumentException, which is standard for invalid parameters.
+      throw IllegalArgumentException("Event with UID ${event.uid} already exists.")
+    }
+    events.add(event)
+    participantsByEvent[event.uid] = mutableListOf()
+  }
+
+  override suspend fun editEvent(eventUid: String, newEvent: Event) {
+    // 'require' correctly throws IllegalArgumentException for precondition failures.
+    require(eventUid == newEvent.uid) { "Event UID mismatch" }
+    val index = events.indexOfFirst { it.uid == eventUid }
+    if (index != -1) {
+      events[index] = newEvent
+    } else {
+      // Throws NoSuchElementException when the item to edit isn't found.
+      throw NoSuchElementException("Cannot edit. Event with UID $eventUid not found.")
+    }
+  }
+
+  override suspend fun deleteEvent(eventUid: String) {
+    val removed = events.removeIf { it.uid == eventUid }
+    if (!removed) {
+      // Throws NoSuchElementException when the item to delete isn't found.
+      throw NoSuchElementException("Cannot delete. Event with UID $eventUid not found.")
+    }
+    participantsByEvent.remove(eventUid)
+  }
+
+  override suspend fun addParticipantToEvent(eventUid: String, participant: EventParticipant) {
+    if (events.none { it.uid == eventUid }) {
+      throw IllegalArgumentException("Event $eventUid does not exist.")
+    }
+
+    val participants = participantsByEvent.getOrPut(eventUid) { mutableListOf() }
+
+    if (participants.any { it.uid == participant.uid }) {
+      throw IllegalStateException("Participant ${participant.uid} is already in event $eventUid.")
+    }
+
+    participants.add(participant)
+  }
+
+  override suspend fun removeParticipantFromEvent(eventUid: String, participantUid: String) {
+    val participants =
+        participantsByEvent[eventUid]
+            ?: throw IllegalArgumentException(
+                "Event $eventUid does not have any participants or does not exist.")
+
+    val removed = participants.removeIf { it.uid == participantUid }
+    if (!removed) {
+      // Throws NoSuchElementException when the participant to remove isn't found in the list.
+      throw NoSuchElementException(
+          "Participant with UID $participantUid not found in event $eventUid.")
+    }
+  }
+}

--- a/app/src/main/java/com/github/se/studentconnect/model/event/EventRepositoryProvider.kt
+++ b/app/src/main/java/com/github/se/studentconnect/model/event/EventRepositoryProvider.kt
@@ -1,7 +1,14 @@
+// Fake events were created by Gemini
 package com.github.se.studentconnect.model.event
 
+import com.github.se.studentconnect.model.location.Location
+import com.google.firebase.Timestamp
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.Date
+import kotlinx.coroutines.runBlocking
 
 /**
  * Provides a single instance of the repository in the app. `repository` is mutable for testing
@@ -9,6 +16,189 @@ import com.google.firebase.ktx.Firebase
  */
 object EventRepositoryProvider {
   private val _repository: EventRepository = EventRepositoryFirestore(Firebase.firestore)
+  private val repository2: EventRepository = EventRepositoryLocal()
 
-  var repository: EventRepository = _repository
+  var repository: EventRepository = repository2
+
+  init {
+    runBlocking {
+      // Event 1
+      repository.addEvent(
+          Event.Public(
+              uid = repository.getNewUid(),
+              ownerId = "ownerId1",
+              title = "The Killers Concert",
+              description =
+                  "Get ready for an epic night! The iconic The Killers are hitting the stage with all their energy, blasting out their legendary hits and fresh new tracks. Huge vibes, a crowd going wild, and sing-along anthems all night long.",
+              imageUrl = null,
+              location = Location(46.5191, 6.5668, "EPFL"),
+              start = Timestamp.now(),
+              end = null,
+              maxCapacity = 2000u,
+              participationFee = 75u,
+              isFlash = false,
+              subtitle = "Live at the EPFL Campus",
+              tags = listOf(),
+              website = ""))
+      // Event 2
+      repository.addEvent(
+          Event.Public(
+              uid = repository.getNewUid(),
+              ownerId = "ownerId2",
+              title = "SQL Workshop",
+              description =
+                  "Join our workshop to master SQL! This session is perfect for beginners and those looking to refresh their skills. We will cover everything from basic queries to more advanced topics. Laptops are required.",
+              imageUrl = null,
+              location = Location(46.5204, 6.5654, "SwissTech Convention Center"),
+              start = date(86400), // 1 day from now
+              end = null,
+              maxCapacity = 50u,
+              participationFee = 10u,
+              isFlash = false,
+              subtitle = "Data Science Student Association",
+              tags = listOf(),
+              website = null))
+
+      // Event 3
+      repository.addEvent(
+          Event.Public(
+              uid = repository.getNewUid(),
+              ownerId = "ownerId3",
+              title = "Balélec Festival 2025",
+              subtitle = "Biggest Student Festival in Europe",
+              description =
+                  "Experience the legendary Balélec Festival at EPFL! Multiple stages, diverse music genres from electronic to rock, food trucks, and an unforgettable atmosphere. Don't miss out on the biggest student-run open-air festival in Europe.",
+              location = Location(46.5191, 6.5668, "EPFL, Lausanne"),
+              start = date(1_209_600),
+              isFlash = false,
+              tags = listOf(),
+              website = ""))
+
+      // Event 4
+      repository.addEvent(
+          Event.Public(
+              uid = repository.getNewUid(),
+              ownerId = "ownerId4",
+              title = "RLC Study Jam",
+              subtitle = "Collaborative Study Session",
+              description =
+                  "Finals are coming! Join our collaborative study session at the Rolex Learning Center. Find study partners, share notes, and enjoy free coffee and snacks to keep you going. Let's ace those exams together!",
+              location = Location(46.5186, 6.5681, "Rolex Learning Center"),
+              start = date(604_800),
+              maxCapacity = 150u,
+              isFlash = false,
+              tags = listOf(),
+              website = null))
+
+      // Event 5
+      repository.addEvent(
+          Event.Public(
+              uid = repository.getNewUid(),
+              ownerId = "ownerId5",
+              title = "Startup Champions Seed Night",
+              subtitle = "EPFL's Premier Pitching Event",
+              description =
+                  "Witness the next generation of innovators at the Startup Champions Seed Night. EPFL's most promising startups will pitch their ideas to a panel of investors and a live audience. Networking session to follow.",
+              location = Location(46.5204, 6.5654, "SwissTech Convention Center"),
+              start = date(2_592_000),
+              isFlash = false,
+              tags = listOf(),
+              website = ""))
+
+      // Event 6
+      repository.addEvent(
+          Event.Public(
+              uid = repository.getNewUid(),
+              ownerId = "ownerId6",
+              title = "O'Week Beach Volleyball",
+              subtitle = "Fun and Sun by the Lake",
+              description =
+                  "Kick off the new semester with some friendly beach volleyball action! Join us by the lake for a casual tournament. All skill levels are welcome. Music, BBQ, and good vibes guaranteed.",
+              location = Location(46.5165, 6.5819, "Plage de Dorigny, Lausanne"),
+              start = date(4_838_400),
+              isFlash = false,
+              tags = listOf(),
+              website = null))
+
+      // Event 7
+      repository.addEvent(
+          Event.Public(
+              uid = repository.getNewUid(),
+              ownerId = "ownerId7",
+              title = "Movie Night Under the Stars",
+              subtitle = "Open-Air Cinema",
+              description =
+                  "Bring a blanket and join us for an open-air movie screening on the EPFL campus. We'll be showing a classic blockbuster. Popcorn is on us! The movie will be announced via a poll on our social media.",
+              location = Location(46.5195, 6.5670, "Esplanade, EPFL"),
+              start = date(950_400),
+              isFlash = false,
+              tags = listOf(),
+              website = null))
+
+      // Event 8
+      repository.addEvent(
+          Event.Public(
+              uid = repository.getNewUid(),
+              ownerId = "ownerId8",
+              title = "International Food Festival",
+              subtitle = "A Taste of the World",
+              description =
+                  "Celebrate the cultural diversity at EPFL! Various student associations will be sharing delicious traditional food from their home countries. Come for the food, stay for the cultural performances and music.",
+              location = Location(46.5196, 6.5654, "Place Cosandey, EPFL"),
+              start = date(400),
+              isFlash = false,
+              tags = listOf(),
+              website = null))
+
+      // Event 9
+      repository.addEvent(
+          Event.Public(
+              uid = repository.getNewUid(),
+              ownerId = "ownerId9",
+              title = "Robotics Club Demo Day",
+              subtitle = "Meet the Machines",
+              description =
+                  "Come see what the Robotics Club has been building all semester! Live demonstrations of autonomous drones, line-following robots, and maybe even a robotic arm that can play chess. A great event for all tech enthusiasts.",
+              location = Location(46.5212, 6.5658, "ME Building, EPFL"),
+              start = date(3_110_400),
+              isFlash = false,
+              tags = listOf(),
+              website = null))
+
+      // Event 10
+      repository.addEvent(
+          Event.Public(
+              uid = repository.getNewUid(),
+              ownerId = "ownerId10",
+              title = "SAT Sailing Regatta",
+              subtitle = "Race on Lake Geneva",
+              description =
+                  "The annual SAT Sailing Regatta is here! Whether you're an experienced sailor or a curious beginner, come and enjoy a day of competitive sailing on the beautiful Lake Geneva. Boats and skippers provided for teams.",
+              location = Location(46.5173, 6.5811, "Centre Nautique de Dorigny"),
+              start = date(4_320_000),
+              isFlash = false,
+              tags = listOf(),
+              website = null))
+
+      // Event 11
+      repository.addEvent(
+          Event.Public(
+              uid = repository.getNewUid(),
+              ownerId = "ownerId11",
+              title = "Board Games Night",
+              subtitle = "Unplug and Play",
+              description =
+                  "Take a break from the screens and join us for a cozy board games night. We have a huge collection from Catan and Ticket to Ride to modern classics. A perfect way to relax and meet new people.",
+              location = Location(46.5209, 6.5683, "CO Building, EPFL"),
+              start = date(345_600),
+              isFlash = false,
+              tags = listOf(),
+              website = null))
+    }
+  }
 }
+
+private fun date(seconds: Long): Timestamp =
+    Timestamp(
+        Date.from(
+            LocalDateTime.now().plusSeconds(seconds).atZone(ZoneId.systemDefault()).toInstant()))

--- a/app/src/main/java/com/github/se/studentconnect/repository/UserRepository.kt
+++ b/app/src/main/java/com/github/se/studentconnect/repository/UserRepository.kt
@@ -10,6 +10,7 @@ import com.github.se.studentconnect.model.User
  */
 interface UserRepository {
 
+  fun leaveEvent(eventId: String, userId: String)
   /**
    * Retrieves a user by their unique identifier.
    *

--- a/app/src/main/java/com/github/se/studentconnect/repository/UserRepositoryFirestore.kt
+++ b/app/src/main/java/com/github/se/studentconnect/repository/UserRepositoryFirestore.kt
@@ -15,6 +15,12 @@ class UserRepositoryFirestore(private val db: FirebaseFirestore) : UserRepositor
     private const val COLLECTION_NAME = "users"
   }
 
+  override fun leaveEvent(eventId: String, userId: String) {
+    db.collection(COLLECTION_NAME)
+        .document(userId)
+        .update("joinedEvents", FieldValue.arrayRemove(eventId))
+  }
+
   override fun getUserById(
       userId: String,
       onSuccess: (User?) -> Unit,

--- a/app/src/main/java/com/github/se/studentconnect/repository/UserRepositoryProvider.kt
+++ b/app/src/main/java/com/github/se/studentconnect/repository/UserRepositoryProvider.kt
@@ -1,0 +1,14 @@
+package com.github.se.studentconnect.repository
+
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+
+/**
+ * Provides a single instance of the repository in the app. `repository` is mutable for testing
+ * purposes.
+ */
+object UserRepositoryProvider {
+  private val _repository: UserRepository = UserRepositoryFirestore(Firebase.firestore)
+
+  var repository: UserRepository = _repository
+}

--- a/app/src/test/java/com/github/se/studentconnect/model/event/EventRepositoryLocalTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/model/event/EventRepositoryLocalTest.kt
@@ -1,0 +1,162 @@
+package com.github.se.studentconnect.model.event
+
+import com.github.se.studentconnect.model.location.Location
+import com.google.firebase.Timestamp
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+
+class EventRepositoryLocalTest {
+
+  private lateinit var eventRepository: EventRepositoryLocal
+
+  private val testEvent =
+      Event.Public(
+          uid = "event1",
+          ownerId = "owner1",
+          title = "Test Event",
+          description = "This is a test event.",
+          location = Location(46.5191, 6.5668, "EPFL"),
+          start = Timestamp.now(),
+          isFlash = false,
+          subtitle = "A subtitle for testing")
+
+  private val testParticipant = EventParticipant(uid = "user1", joinedAt = Timestamp.now())
+
+  @Before
+  fun setUp() {
+    eventRepository = EventRepositoryLocal()
+  }
+
+  @Test
+  fun getNewUid_generatesUniqueNonEmptyIds() {
+    val uid1 = eventRepository.getNewUid()
+    assertTrue(uid1.isNotEmpty())
+    val uid2 = eventRepository.getNewUid()
+    assertTrue(uid2.isNotEmpty())
+    assert(uid1 != uid2)
+  }
+
+  @Test
+  fun addAndGetEvent_succeeds() = runTest {
+    eventRepository.addEvent(testEvent)
+    val allEvents = eventRepository.getAllVisibleEvents()
+    assertEquals(1, allEvents.size)
+    assertTrue(allEvents.contains(testEvent))
+    val retrievedEvent = eventRepository.getEvent("event1")
+    assertEquals(testEvent, retrievedEvent)
+  }
+
+  @Test
+  fun getEvent_throwsErrorWhenNotFound() {
+    assertThrows(NoSuchElementException::class.java) {
+      runTest { eventRepository.getEvent("non-existent-id") }
+    }
+  }
+
+  @Test
+  fun editEvent_succeeds() = runTest {
+    eventRepository.addEvent(testEvent)
+    val updatedEvent = testEvent.copy(title = "Updated Event Title")
+    eventRepository.editEvent("event1", updatedEvent)
+    val retrievedEvent = eventRepository.getEvent("event1")
+    assertEquals("Updated Event Title", retrievedEvent.title)
+    val allEvents = eventRepository.getAllVisibleEvents()
+    assertEquals(1, allEvents.size)
+    assertFalse(allEvents.contains(testEvent))
+    assertTrue(allEvents.contains(updatedEvent))
+  }
+
+  @Test
+  fun deleteEvent_succeeds() = runTest {
+    eventRepository.addEvent(testEvent)
+    eventRepository.addParticipantToEvent("event1", testParticipant)
+    assertEquals(1, eventRepository.getAllVisibleEvents().size)
+    assertEquals(1, eventRepository.getEventParticipants("event1").size)
+    eventRepository.deleteEvent("event1")
+    assertEquals(0, eventRepository.getAllVisibleEvents().size)
+    assertEquals(0, eventRepository.getEventParticipants("event1").size)
+  }
+
+  @Test
+  fun deleteEvent_deletesTheCorrectEvent() = runTest {
+    val event2 = testEvent.copy(uid = "event2", title = "Second Event")
+    eventRepository.addEvent(testEvent)
+    eventRepository.addEvent(event2)
+    eventRepository.deleteEvent("event1")
+    val allEvents = eventRepository.getAllVisibleEvents()
+    assertEquals(1, allEvents.size)
+    assertFalse(allEvents.any { it.uid == "event1" })
+    assertTrue(allEvents.any { it.uid == "event2" })
+  }
+
+  @Test
+  fun deleteEvent_throwsErrorWhenNotFound() {
+    assertThrows(NoSuchElementException::class.java) {
+      runTest { eventRepository.deleteEvent("non-existent-id") }
+    }
+  }
+
+  @Test
+  fun getAllVisibleEventsSatisfying_returnsCorrectlyFilteredEvents() = runTest {
+    val flashEvent = testEvent.copy(uid = "event2", isFlash = true)
+    eventRepository.addEvent(testEvent)
+    eventRepository.addEvent(flashEvent)
+    val flashEvents = eventRepository.getAllVisibleEventsSatisfying { it.isFlash }
+    assertEquals(1, flashEvents.size)
+    assertEquals("event2", flashEvents[0].uid)
+    val nonFlashEvents = eventRepository.getAllVisibleEventsSatisfying { !it.isFlash }
+    assertEquals(1, nonFlashEvents.size)
+    assertEquals("event1", nonFlashEvents[0].uid)
+  }
+
+  @Test
+  fun addAndGetParticipants_succeeds() = runTest {
+    eventRepository.addEvent(testEvent)
+    eventRepository.addParticipantToEvent("event1", testParticipant)
+    val participants = eventRepository.getEventParticipants("event1")
+    assertEquals(1, participants.size)
+    assertEquals("user1", participants[0].uid)
+  }
+
+  @Test
+  fun addParticipant_throwsErrorWhenEventNotFound() {
+    assertThrows(IllegalArgumentException::class.java) {
+      runTest { eventRepository.addParticipantToEvent("non-existent-event", testParticipant) }
+    }
+  }
+
+  @Test
+  fun addParticipant_throwsErrorOnDuplicate() = runTest {
+    eventRepository.addEvent(testEvent)
+    eventRepository.addParticipantToEvent("event1", testParticipant)
+    assertThrows(IllegalStateException::class.java) {
+      runTest { eventRepository.addParticipantToEvent("event1", testParticipant) }
+    }
+  }
+
+  @Test
+  fun removeParticipant_succeeds() = runTest {
+    eventRepository.addEvent(testEvent)
+    eventRepository.addParticipantToEvent("event1", testParticipant)
+    assertEquals(1, eventRepository.getEventParticipants("event1").size)
+    eventRepository.removeParticipantFromEvent("event1", "user1")
+    assertEquals(0, eventRepository.getEventParticipants("event1").size)
+  }
+
+  @Test
+  fun getEventsAttendedByUser_returnsAllEvents_asPerCurrentImplementation() = runTest {
+    val event2 = testEvent.copy(uid = "event2")
+    eventRepository.addEvent(testEvent)
+    eventRepository.addEvent(event2)
+    eventRepository.addParticipantToEvent("event1", testParticipant)
+    val eventsForUser = eventRepository.getEventsAttendedByUser(testParticipant.uid)
+    assertEquals(2, eventsForUser.size)
+    assertTrue(eventsForUser.contains(testEvent))
+    assertTrue(eventsForUser.contains(event2))
+  }
+}


### PR DESCRIPTION
This PR (fixes #13) gets the backend started for the new `Activities` feature. I've laid the groundwork for managing which events users have joined. 

Here's what I've done:
- Updated the User model: I've added a `joinedEvents` list to the `User.kt` data class. This will let us keep track of the events each user signs up for.
- Added a local repository for testing: I created `EventRepositoryLocal.kt` so we can run tests on the activities logic without needing to connect to a real database. It's just an in-memory version for now.
- Added `UserRepositoryFirestore.kt` to manage user data in Firestore, specifically for handling the new `joinedEvents`.
- Added a `leaveEvent` method: Users now have a way to leave an event they've joined.

Added unit tests for the new local event repository.