### PR TITLE
fix(ci): correct artifact paths for SonarCloud analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
           path: |
             app/build/test-results/**/*.xml
             app/build/reports/tests/**
+            app/build/outputs/unit_test_code_coverage/**/*.exec
 
 
   instrumented-tests:
@@ -202,6 +203,7 @@ jobs:
           path: |
             app/build/outputs/androidTest-results/**/*.xml
             app/build/reports/androidTests/**
+            app/build/outputs/code_coverage/**/*.ec
 
 
   sonarcloud:
@@ -240,41 +242,41 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: unit-test-results
-          path: app/build/test-results/
+          path: app/build/
 
       - name: Download instrumented test results (shard 0)
         uses: actions/download-artifact@v4
         with:
           name: instrumented-test-results-shard-0
-          path: app/build/outputs/androidTest-results/shard-0/
+          path: app/build/
         continue-on-error: true
 
       - name: Download instrumented test results (shard 1)
         uses: actions/download-artifact@v4
         with:
           name: instrumented-test-results-shard-1
-          path: app/build/outputs/androidTest-results/shard-1/
+          path: app/build/
         continue-on-error: true
 
       - name: Download instrumented test results (shard 2)
         uses: actions/download-artifact@v4
         with:
           name: instrumented-test-results-shard-2
-          path: app/build/outputs/androidTest-results/shard-2/
+          path: app/build/
         continue-on-error: true
 
       - name: Download instrumented test results (shard 3)
         uses: actions/download-artifact@v4
         with:
           name: instrumented-test-results-shard-3
-          path: app/build/outputs/androidTest-results/shard-3/
+          path: app/build/
         continue-on-error: true
 
       - name: Download instrumented test results (shard 4)
         uses: actions/download-artifact@v4
         with:
           name: instrumented-test-results-shard-4
-          path: app/build/outputs/androidTest-results/shard-4/
+          path: app/build/
         continue-on-error: true
 
       - name: Generate Coverage Report


### PR DESCRIPTION
## Summary

Fixes test report and coverage artifact paths in the CI workflow to ensure proper upload to SonarCloud.

## Problem

The SonarCloud job was failing to analyze test results because artifacts were being uploaded with their full directory structure but downloaded to specific subdirectories, causing a path mismatch. Additionally, coverage files (`.exec` and `.ec`) were not included in the uploaded artifacts.

## Solution

- Changed all artifact download paths in the `sonarcloud` job from specific subdirectories to `app/build/` to match the upload structure
- Added coverage file paths to artifact uploads:
  - `app/build/outputs/unit_test_code_coverage/**/*.exec` for unit tests
  - `app/build/outputs/code_coverage/**/*.ec` for instrumented tests

## Changes

- Updated artifact download paths for unit test results
- Updated artifact download paths for all instrumented test result shards (0-4)
- Enhanced artifact uploads to include coverage files

This ensures SonarCloud can properly locate and analyze all test results and coverage data.