### PR TITLE
fix: add back broken navigation

### DIFF
--- a/app/src/main/java/com/github/se/studentconnect/MainActivity.kt
+++ b/app/src/main/java/com/github/se/studentconnect/MainActivity.kt
@@ -182,7 +182,12 @@ private fun MainAppContent(
                 restoreState = true
               }
             },
-        )
+            onCreatePublicEvent = {
+              navController.navigate(Route.CREATE_PUBLIC_EVENT) { launchSingleTop = true }
+            },
+            onCreatePrivateEvent = {
+              navController.navigate(Route.CREATE_PRIVATE_EVENT) { launchSingleTop = true }
+            })
       }) { paddingValues ->
         // Use real repository from provider
         val userRepository = UserRepositoryProvider.repository


### PR DESCRIPTION
## What?

Fix navigation which was broken by some incorrect merge.

## Why?

Navigating to the map page and the create events page made the app crash.

## How?

By adding back the lines of code which were deleted in `MainActivity.kt`.