### PR TITLE
Add event banner image upload

### DIFF
--- a/app/src/androidTest/java/com/github/se/studentconnect/ui/eventcreation/CreatePrivateEventScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/studentconnect/ui/eventcreation/CreatePrivateEventScreenTest.kt
@@ -138,6 +138,15 @@ class CreatePrivateEventScreenTest : StudentConnectTest() {
   }
 
   @Test
+  fun bannerPicker_isDisplayed() {
+    waitForTag(CreatePrivateEventScreenTestTags.BANNER_PICKER)
+    composeTestRule
+        .onNodeWithTag(CreatePrivateEventScreenTestTags.BANNER_PICKER)
+        .performScrollTo()
+        .assertIsDisplayed()
+  }
+
+  @Test
   fun saveButton_disabled_whenMandatoryFieldsEmpty() {
     waitForTag(CreatePrivateEventScreenTestTags.SAVE_BUTTON)
     composeTestRule

--- a/app/src/androidTest/java/com/github/se/studentconnect/ui/eventcreation/CreatePublicEventScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/studentconnect/ui/eventcreation/CreatePublicEventScreenTest.kt
@@ -150,6 +150,15 @@ class CreatePublicEventScreenTest : StudentConnectTest() {
   }
 
   @Test
+  fun bannerPicker_isDisplayed() {
+    waitForTag(CreatePublicEventScreenTestTags.BANNER_PICKER)
+    composeTestRule
+        .onNodeWithTag(CreatePublicEventScreenTestTags.BANNER_PICKER)
+        .performScrollTo()
+        .assertIsDisplayed()
+  }
+
+  @Test
   fun saveButton_disabled_whenMandatoryFieldsEmpty() {
     waitForTag(CreatePublicEventScreenTestTags.SAVE_BUTTON)
     composeTestRule

--- a/app/src/main/java/com/github/se/studentconnect/ui/components/PicturePickerCard.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/components/PicturePickerCard.kt
@@ -1,0 +1,205 @@
+package com.github.se.studentconnect.ui.components
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.github.se.studentconnect.model.media.MediaRepositoryProvider
+import java.io.InputStream
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+enum class PicturePickerStyle {
+  Avatar,
+  Banner
+}
+
+@Composable
+fun PicturePickerCard(
+    modifier: Modifier = Modifier,
+    style: PicturePickerStyle = PicturePickerStyle.Avatar,
+    existingImagePath: String?,
+    selectedImageUri: Uri?,
+    onImageSelected: (Uri) -> Unit,
+    placeholderText: String,
+    overlayText: String,
+    imageDescription: String,
+    placeholderIcon: androidx.compose.ui.graphics.vector.ImageVector? = null
+) {
+  val repository = MediaRepositoryProvider.repository
+  var downloadedImageUri by remember(existingImagePath, repository) { mutableStateOf<Uri?>(null) }
+  val context = LocalContext.current
+
+  LaunchedEffect(existingImagePath, repository) {
+    downloadedImageUri =
+        existingImagePath?.let {
+          runCatching { withContext(Dispatchers.IO) { repository.download(it) } }.getOrNull()
+        }
+  }
+
+  val displayUri = selectedImageUri ?: downloadedImageUri
+  var imageBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
+
+  LaunchedEffect(displayUri) {
+    imageBitmap =
+        if (displayUri != null) {
+          loadBitmapFromUri(context, displayUri)
+        } else {
+          null
+        }
+  }
+
+  val pickMediaLauncher =
+      rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
+        uri?.let(onImageSelected)
+      }
+
+  val shape =
+      when (style) {
+        PicturePickerStyle.Avatar -> CircleShape
+        PicturePickerStyle.Banner -> RoundedCornerShape(20.dp)
+      }
+
+  val dashEffect = remember { PathEffect.dashPathEffect(floatArrayOf(18f, 16f), 0f) }
+  val borderColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+  val sizeModifier =
+      when (style) {
+        PicturePickerStyle.Avatar -> Modifier.size(140.dp)
+        PicturePickerStyle.Banner -> Modifier.fillMaxWidth().height(200.dp)
+      }
+
+  Box(
+      modifier =
+          modifier
+              .then(sizeModifier)
+              .clip(shape)
+              .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.2f))
+              .clickable {
+                pickMediaLauncher.launch(
+                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+              }
+              .dashedBorder(shape, dashEffect, borderColor),
+      contentAlignment = Alignment.Center) {
+        if (imageBitmap != null) {
+          Image(
+              bitmap = imageBitmap!!,
+              contentDescription = imageDescription,
+              modifier = Modifier.matchParentSize(),
+              contentScale = ContentScale.Crop)
+          Text(
+              text = overlayText,
+              style =
+                  MaterialTheme.typography.bodySmall.copy(
+                      color = MaterialTheme.colorScheme.onSurfaceVariant),
+              textAlign = TextAlign.Center,
+              modifier =
+                  Modifier.align(Alignment.BottomCenter)
+                      .padding(bottom = 16.dp)
+                      .background(
+                          color = MaterialTheme.colorScheme.surface.copy(alpha = 0.85f),
+                          shape = RoundedCornerShape(12.dp))
+                      .padding(horizontal = 12.dp, vertical = 6.dp))
+        } else {
+          Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            val icon =
+                placeholderIcon
+                    ?: when (style) {
+                      PicturePickerStyle.Avatar -> Icons.Default.Person
+                      PicturePickerStyle.Banner -> Icons.Default.Image
+                    }
+            Icon(
+                imageVector = icon,
+                contentDescription = imageDescription,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier =
+                    when (style) {
+                      PicturePickerStyle.Avatar -> Modifier.size(60.dp)
+                      PicturePickerStyle.Banner -> Modifier.size(48.dp)
+                    })
+            Spacer(Modifier.height(16.dp))
+            Text(
+                text = placeholderText,
+                style =
+                    MaterialTheme.typography.bodyMedium.copy(
+                        color = MaterialTheme.colorScheme.onSurfaceVariant),
+                textAlign = TextAlign.Center)
+          }
+        }
+      }
+}
+
+private fun Modifier.dashedBorder(shape: Shape, pathEffect: PathEffect, color: Color): Modifier =
+    this.then(
+        Modifier.drawBehind {
+          val stroke = Stroke(width = 3.dp.toPx(), pathEffect = pathEffect)
+          when (val outline = shape.createOutline(size, layoutDirection, this)) {
+            is Outline.Rectangle -> drawRect(color = color, size = size, style = stroke)
+            is Outline.Rounded ->
+                drawRoundRect(
+                    color = color,
+                    size = size,
+                    style = stroke,
+                    cornerRadius = CornerRadius(outline.roundRect.topLeftCornerRadius.x))
+            is Outline.Generic -> drawPath(outline.path, color = color, style = stroke)
+          }
+        })
+
+private suspend fun loadBitmapFromUri(context: Context, uri: Uri): ImageBitmap? =
+    withContext(Dispatchers.IO) {
+      try {
+        when (uri.scheme?.lowercase()) {
+          "file" -> uri.path?.let { path -> BitmapFactory.decodeFile(path)?.asImageBitmap() }
+          else ->
+              context.contentResolver.openInputStream(uri)?.use { stream ->
+                decodeStream(stream)?.asImageBitmap()
+              }
+        }
+      } catch (_: Exception) {
+        null
+      }
+    }
+
+private fun decodeStream(stream: InputStream): Bitmap? = BitmapFactory.decodeStream(stream)

--- a/app/src/main/java/com/github/se/studentconnect/ui/eventcreation/CreateEventUiState.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/eventcreation/CreateEventUiState.kt
@@ -1,5 +1,6 @@
 package com.github.se.studentconnect.ui.eventcreation
 
+import android.net.Uri
 import com.github.se.studentconnect.model.location.Location
 import java.time.LocalDate
 import java.time.LocalTime
@@ -21,6 +22,9 @@ sealed class CreateEventUiState {
   abstract val isFlash: Boolean
   abstract val finishedSaving: Boolean
   abstract val isSaving: Boolean
+  abstract val bannerImageUri: Uri?
+  abstract val bannerImagePath: String?
+  abstract val shouldRemoveBanner: Boolean
 
   data class Public(
       override val title: String = "",
@@ -36,6 +40,9 @@ sealed class CreateEventUiState {
       override val isFlash: Boolean = false,
       override val finishedSaving: Boolean = false,
       override val isSaving: Boolean = false,
+      override val bannerImageUri: Uri? = null,
+      override val bannerImagePath: String? = null,
+      override val shouldRemoveBanner: Boolean = false,
       val subtitle: String = "",
       val website: String = "",
       val tags: List<String> = emptyList(),
@@ -55,5 +62,8 @@ sealed class CreateEventUiState {
       override val isFlash: Boolean = false,
       override val finishedSaving: Boolean = false,
       override val isSaving: Boolean = false,
+      override val bannerImageUri: Uri? = null,
+      override val bannerImagePath: String? = null,
+      override val shouldRemoveBanner: Boolean = false,
   ) : CreateEventUiState()
 }

--- a/app/src/main/java/com/github/se/studentconnect/ui/eventcreation/CreatePrivateEventScreen.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/eventcreation/CreatePrivateEventScreen.kt
@@ -15,7 +15,11 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.SaveAlt
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -26,10 +30,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
+import com.github.se.studentconnect.ui.components.PicturePickerCard
+import com.github.se.studentconnect.ui.components.PicturePickerStyle
 import com.github.se.studentconnect.ui.theme.AppTheme
 import java.time.format.DateTimeFormatter
 
@@ -46,6 +53,8 @@ object CreatePrivateEventScreenTestTags {
   const val PARTICIPATION_FEE_SWITCH = "participationFeeSwitch"
   const val FLASH_EVENT_SWITCH = "flashEventSwitch"
   const val SAVE_BUTTON = "saveButton"
+  const val BANNER_PICKER = "bannerPicker"
+  const val REMOVE_BANNER_BUTTON = "removeBannerButton"
 }
 
 @Composable
@@ -103,6 +112,46 @@ fun CreatePrivateEventScreen(
         value = createPrivateEventUiState.description,
         onValueChange = { createPrivateEventViewModel.updateDescription(it) },
     )
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+          Column(
+              modifier = Modifier.padding(16.dp),
+              verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    text = "Event Banner",
+                    style =
+                        MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold))
+                PicturePickerCard(
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .testTag(CreatePrivateEventScreenTestTags.BANNER_PICKER),
+                    style = PicturePickerStyle.Banner,
+                    existingImagePath = createPrivateEventUiState.bannerImagePath,
+                    selectedImageUri = createPrivateEventUiState.bannerImageUri,
+                    onImageSelected = { uri ->
+                      createPrivateEventViewModel.updateBannerImageUri(uri)
+                    },
+                    placeholderText = "Upload a banner for your event",
+                    overlayText = "Tap to change banner",
+                    imageDescription = "Event banner")
+                Text(
+                    text = "Add a banner so attendees can quickly recognize your event.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+                OutlinedButton(
+                    onClick = { createPrivateEventViewModel.removeBannerImage() },
+                    enabled =
+                        createPrivateEventUiState.bannerImageUri != null ||
+                            createPrivateEventUiState.bannerImagePath != null,
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .testTag(CreatePrivateEventScreenTestTags.REMOVE_BANNER_BUTTON)) {
+                      Text("Remove banner")
+                    }
+              }
+        }
 
     LocationTextField(
         modifier = Modifier.fillMaxWidth().testTag(CreatePrivateEventScreenTestTags.LOCATION_INPUT),

--- a/app/src/main/java/com/github/se/studentconnect/ui/eventcreation/CreatePublicEventScreen.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/eventcreation/CreatePublicEventScreen.kt
@@ -15,7 +15,11 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.SaveAlt
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -26,10 +30,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
+import com.github.se.studentconnect.ui.components.PicturePickerCard
+import com.github.se.studentconnect.ui.components.PicturePickerStyle
 import com.github.se.studentconnect.ui.theme.AppTheme
 import java.time.format.DateTimeFormatter
 
@@ -48,6 +55,8 @@ object CreatePublicEventScreenTestTags {
   const val PARTICIPATION_FEE_SWITCH = "participationFeeSwitch"
   const val FLASH_EVENT_SWITCH = "flashEventSwitch"
   const val SAVE_BUTTON = "saveButton"
+  const val BANNER_PICKER = "bannerPicker"
+  const val REMOVE_BANNER_BUTTON = "removeBannerButton"
 }
 
 @Composable
@@ -138,6 +147,46 @@ fun CreatePublicEventScreen(
         value = createPublicEventUiState.description,
         onValueChange = { createPublicEventViewModel.updateDescription(it) },
     )
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+          Column(
+              modifier = Modifier.padding(16.dp),
+              verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    text = "Event Banner",
+                    style =
+                        MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold))
+                PicturePickerCard(
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .testTag(CreatePublicEventScreenTestTags.BANNER_PICKER),
+                    style = PicturePickerStyle.Banner,
+                    existingImagePath = createPublicEventUiState.bannerImagePath,
+                    selectedImageUri = createPublicEventUiState.bannerImageUri,
+                    onImageSelected = { uri ->
+                      createPublicEventViewModel.updateBannerImageUri(uri)
+                    },
+                    placeholderText = "Upload a banner for your event page",
+                    overlayText = "Tap to change banner",
+                    imageDescription = "Event banner")
+                Text(
+                    text = "A banner makes your public event stand out in search results.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+                OutlinedButton(
+                    onClick = { createPublicEventViewModel.removeBannerImage() },
+                    enabled =
+                        createPublicEventUiState.bannerImageUri != null ||
+                            createPublicEventUiState.bannerImagePath != null,
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .testTag(CreatePublicEventScreenTestTags.REMOVE_BANNER_BUTTON)) {
+                      Text("Remove banner")
+                    }
+              }
+        }
 
     LocationTextField(
         modifier = Modifier.fillMaxWidth().testTag(CreatePublicEventScreenTestTags.LOCATION_INPUT),

--- a/app/src/main/java/com/github/se/studentconnect/ui/eventcreation/CreatePublicEventViewModel.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/eventcreation/CreatePublicEventViewModel.kt
@@ -1,11 +1,14 @@
 package com.github.se.studentconnect.ui.eventcreation
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.se.studentconnect.model.event.Event
 import com.github.se.studentconnect.model.event.EventRepository
 import com.github.se.studentconnect.model.event.EventRepositoryProvider
 import com.github.se.studentconnect.model.location.Location
+import com.github.se.studentconnect.model.media.MediaRepository
+import com.github.se.studentconnect.model.media.MediaRepositoryProvider
 import com.google.firebase.Firebase
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.auth
@@ -19,7 +22,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class CreatePublicEventViewModel(
-    private val eventRepository: EventRepository = EventRepositoryProvider.repository
+    private val eventRepository: EventRepository = EventRepositoryProvider.repository,
+    private val mediaRepository: MediaRepository = MediaRepositoryProvider.repository
 ) : ViewModel() {
   private val _uiState = MutableStateFlow(CreateEventUiState.Public())
   val uiState: StateFlow<CreateEventUiState.Public> = _uiState.asStateFlow()
@@ -69,6 +73,15 @@ class CreatePublicEventViewModel(
     _uiState.value = uiState.value.copy(isFlash = newIsFlash)
   }
 
+  fun updateBannerImageUri(newUri: Uri) {
+    _uiState.value = uiState.value.copy(bannerImageUri = newUri, shouldRemoveBanner = false)
+  }
+
+  fun removeBannerImage() {
+    _uiState.value =
+        uiState.value.copy(bannerImageUri = null, bannerImagePath = null, shouldRemoveBanner = true)
+  }
+
   fun updateSubtitle(newSubtitle: String) {
     _uiState.value = uiState.value.copy(subtitle = newSubtitle)
   }
@@ -109,6 +122,7 @@ class CreatePublicEventViewModel(
             subtitle = event.subtitle,
             website = event.website.orEmpty(),
             tags = event.tags,
+            bannerImagePath = event.imageUrl,
         )
   }
 
@@ -121,74 +135,91 @@ class CreatePublicEventViewModel(
   }
 
   fun saveEvent() {
-    val canSave =
-        uiState.value.title.isNotBlank() &&
-            uiState.value.startDate != null &&
-            uiState.value.endDate != null
+    val state = uiState.value
+    val canSave = state.title.isNotBlank() && state.startDate != null && state.endDate != null
     check(canSave)
 
     val currentUserId = Firebase.auth.currentUser?.uid
     checkNotNull(currentUserId)
 
-    _uiState.value = uiState.value.copy(isSaving = true)
-
-    val start =
-        LocalDateTime.of(uiState.value.startDate, uiState.value.startTime).let {
-          val instant = it.atZone(ZoneId.systemDefault()).toInstant()
-
-          Timestamp(instant)
-        }
-
-    val end =
-        LocalDateTime.of(uiState.value.endDate, uiState.value.endTime).let {
-          val instant = it.atZone(ZoneId.systemDefault()).toInstant()
-
-          Timestamp(instant)
-        }
-
-    val maxCapacity =
-        try {
-          uiState.value.numberOfParticipantsString.toUInt()
-        } catch (_: Exception) {
-          null
-        }
-
-    val participationFee =
-        try {
-          uiState.value.participationFeeString.toUInt()
-        } catch (_: Exception) {
-          null
-        }
-
+    _uiState.value = state.copy(isSaving = true)
     val eventUid = editingEventUid ?: eventRepository.getNewUid()
-    val event =
-        Event.Public(
-            uid = eventUid,
-            ownerId = currentUserId,
-            title = uiState.value.title,
-            description = uiState.value.description,
-            imageUrl = null,
-            location = uiState.value.location,
-            start = start,
-            end = end,
-            maxCapacity = maxCapacity,
-            participationFee = participationFee,
-            isFlash = uiState.value.isFlash,
-            subtitle = uiState.value.subtitle,
-            tags = uiState.value.tags,
-            website = uiState.value.website)
 
     viewModelScope.launch {
       try {
+        val latestState = uiState.value
+        val start =
+            LocalDateTime.of(latestState.startDate!!, latestState.startTime).let {
+              val instant = it.atZone(ZoneId.systemDefault()).toInstant()
+              Timestamp(instant)
+            }
+
+        val end =
+            LocalDateTime.of(latestState.endDate!!, latestState.endTime).let {
+              val instant = it.atZone(ZoneId.systemDefault()).toInstant()
+              Timestamp(instant)
+            }
+
+        val maxCapacity =
+            try {
+              latestState.numberOfParticipantsString.toUInt()
+            } catch (_: Exception) {
+              null
+            }
+
+        val participationFee =
+            try {
+              latestState.participationFeeString.toUInt()
+            } catch (_: Exception) {
+              null
+            }
+
+        val bannerPath = resolveBannerImagePath(eventUid, latestState)
+
+        val event =
+            Event.Public(
+                uid = eventUid,
+                ownerId = currentUserId,
+                title = latestState.title,
+                description = latestState.description,
+                imageUrl = bannerPath,
+                location = latestState.location,
+                start = start,
+                end = end,
+                maxCapacity = maxCapacity,
+                participationFee = participationFee,
+                isFlash = latestState.isFlash,
+                subtitle = latestState.subtitle,
+                tags = latestState.tags,
+                website = latestState.website)
+
         if (editingEventUid != null) {
           eventRepository.editEvent(eventUid, event)
         } else {
           eventRepository.addEvent(event)
         }
-        _uiState.value = uiState.value.copy(isSaving = false, finishedSaving = true)
+        _uiState.value =
+            uiState.value.copy(
+                isSaving = false,
+                finishedSaving = true,
+                bannerImageUri = null,
+                bannerImagePath = bannerPath,
+                shouldRemoveBanner = false)
       } catch (_: Exception) {
         _uiState.value = uiState.value.copy(isSaving = false, finishedSaving = false)
       }
+    }
+  }
+
+  private suspend fun resolveBannerImagePath(
+      eventUid: String,
+      state: CreateEventUiState.Public
+  ): String? {
+    return when {
+      state.bannerImageUri != null ->
+          mediaRepository.upload(state.bannerImageUri, "events/$eventUid/banner")
+      state.shouldRemoveBanner -> null
+      else -> state.bannerImagePath
     }
   }
 }


### PR DESCRIPTION
## What?

Add event banner upload for events in event creation and editing screens.

<img src="https://github.com/user-attachments/assets/524d457a-0552-429a-9a98-ebb7759b1afd" width=30% />

## Why?

So event creators can show others a picture that represents themselves.
This resolves #121.

## How?

The `CreatePublicEventScreen` and `CreatePrivateEventScreen` now use a shared component for uploading the event image.