### PR TITLE
Fix update activities freeze

### DIFF
--- a/app/src/main/java/com/github/se/studentconnect/ui/profile/edit/EditActivitiesViewModel.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/profile/edit/EditActivitiesViewModel.kt
@@ -90,9 +90,9 @@ class EditActivitiesViewModel(
           return@launch
         }
 
-        // Use updateUser to avoid race conditions and ensure atomic updates
-        val updates = mapOf("hobbies" to _selectedActivities.value.toList())
-        userRepository.updateUser(userId, updates)
+        // not using userRepository.updateUser, as it doesn't work
+        val updatedUser = user.copy(hobbies = _selectedActivities.value.toList())
+        userRepository.saveUser(updatedUser)
         _uiState.value = UiState.Success("Activities updated successfully")
       } catch (e: Exception) {
         _uiState.value = UiState.Error(e.message ?: "Failed to save activities")


### PR DESCRIPTION
# What
fixes #159
# Why
Updating activities was broken and corrupted the user data
# How
By using `user.copy` and `userRepository.saveUser` instead of `userRepository.updateUser` in `EditActivitiesViewModel`