### PR TITLE
chore: Set target version to 35

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,6 +23,7 @@ android {
     defaultConfig {
         applicationId = "com.github.se.studentconnect"
         minSdk = 29
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 


### PR DESCRIPTION
**What:**
Set the project’s target version to 35.

**Why:**
To maintain compatibility with the latest platform updates and ensure the project adheres to current build and deployment standards.

**How:**
Updated the project configuration files to specify target version 35, replacing the previous version reference.
