### PR TITLE
feat(ActivitiesViewModel): optimize event filtering

### DIFF
--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/activities/ActivitiesViewModel.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/activities/ActivitiesViewModel.kt
@@ -107,17 +107,21 @@ class ActivitiesViewModel(
                   }
 
               val eventsFromAllVisible =
-                  allVisibleEvents.filter { ev -> ev.ownerId == userUid || joinedEventIds.contains(ev.uid) }
+                  allVisibleEvents.filter { ev ->
+                    ev.ownerId == userUid || joinedEventIds.contains(ev.uid)
+                  }
 
-              val joinedOnlyIds = joinedEventIds.filterNot { id -> eventsFromAllVisible.any { it.uid == id } }
+              val joinedOnlyIds =
+                  joinedEventIds.filterNot { id -> eventsFromAllVisible.any { it.uid == id } }
 
-              val joinedEvents = joinedOnlyIds.mapNotNull { eventId ->
-                try {
-                  eventRepository.getEvent(eventId)
-                } catch (_: Exception) {
-                  null
-                }
-              }
+              val joinedEvents =
+                  joinedOnlyIds.mapNotNull { eventId ->
+                    try {
+                      eventRepository.getEvent(eventId)
+                    } catch (_: Exception) {
+                      null
+                    }
+                  }
 
               val now = Timestamp.now()
               (eventsFromAllVisible + joinedEvents)


### PR DESCRIPTION
## What
This PR fixes an issue where newly joined events weren't appearing in the main activity's upcoming events section after clicking the "join event" button.

## Why
Users expect immediate feedback when they join an event. Without the event appearing in the upcoming events section, users may be confused about whether their action was successful, leading to a poor user experience and potential duplicate join attempts.

## How
Updated the event join handler to refresh the upcoming events list after a successful join operation
Ensured the main activity properly observes and displays newly joined events in the upcoming events section
Added proper state synchronization between the join event action and the main activity view