### PR TITLE
hotfix: fix getting coverage data from android tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,9 +432,10 @@ jobs:
         run: |
           mkdir -p $BASE
 
-          for i in $(seq 0 $((SHARD_COUNT - 1))); do
-            mkdir -p "$BASE/shard-$i"
-            mv android-ec-$i/**/coverage.ec "$BASE/shard-$i/"
+          for dir in android-ec-*; do
+            shard="${dir##android-ec-}"
+            mkdir -p "$BASE/shard-$shard"
+            mv "$dir"/coverage.ec "$BASE/shard-$shard/"
           done
 
       - name: Download lint report

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -356,6 +356,14 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
     })
 }
 
+// Debug to check files given to Jacoco
+tasks.named<JacocoReport>("jacocoTestReport") {
+    doFirst {
+        println("=== Jacoco executionData files ===")
+        executionData.files.forEach { println(it.absolutePath) }
+    }
+}
+
 configurations.forEach { configuration ->
     // Exclude protobuf-lite from all configurations
     // This fixes a fatal exception for tests interacting with Cloud Firestore


### PR DESCRIPTION
## What?

This is a hotfix after merging #135.

## Why?

The coverage data from android tests was not taken into account by Jacoco.
This fixes it.

## How?

By correctly moving the `coverage.ec` files to the right place.