### PR TITLE
refactor(signup): organize signup screens into subpackages

### DIFF
--- a/app/src/androidTest/java/com/github/se/studentconnect/ui/screen/signup/AddPictureScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/studentconnect/ui/screen/signup/AddPictureScreenTest.kt
@@ -14,6 +14,8 @@ import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.se.studentconnect.R
+import com.github.se.studentconnect.ui.screen.signup.regularuser.AddPictureScreen
+import com.github.se.studentconnect.ui.screen.signup.regularuser.SignUpViewModel
 import com.github.se.studentconnect.ui.theme.AppTheme
 import java.io.File
 import java.io.FileOutputStream

--- a/app/src/androidTest/java/com/github/se/studentconnect/ui/screen/signup/BasicInfoScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/studentconnect/ui/screen/signup/BasicInfoScreenTest.kt
@@ -12,6 +12,8 @@ import com.github.se.studentconnect.MainActivity
 import com.github.se.studentconnect.model.User
 import com.github.se.studentconnect.model.event.EventRepositoryLocal
 import com.github.se.studentconnect.repository.UserRepositoryLocal
+import com.github.se.studentconnect.ui.screen.signup.regularuser.BasicInfoScreen
+import com.github.se.studentconnect.ui.screen.signup.regularuser.SignUpViewModel
 import com.github.se.studentconnect.ui.theme.AppTheme
 import com.github.se.studentconnect.utils.StudentConnectTest
 import com.google.firebase.Timestamp

--- a/app/src/androidTest/java/com/github/se/studentconnect/ui/screen/signup/OrganizationLogoScreenTest.kt
+++ b/app/src/androidTest/java/com/github/se/studentconnect/ui/screen/signup/OrganizationLogoScreenTest.kt
@@ -12,6 +12,9 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.se.studentconnect.R
+import com.github.se.studentconnect.ui.screen.signup.organization.OrganizationLogoScreen
+import com.github.se.studentconnect.ui.screen.signup.regularuser.DEFAULT_PLACEHOLDER
+import com.github.se.studentconnect.ui.screen.signup.regularuser.SignUpViewModel
 import com.github.se.studentconnect.ui.theme.AppTheme
 import java.io.File
 import java.io.FileOutputStream

--- a/app/src/main/java/com/github/se/studentconnect/MainActivity.kt
+++ b/app/src/main/java/com/github/se/studentconnect/MainActivity.kt
@@ -51,8 +51,8 @@ import com.github.se.studentconnect.ui.screen.profile.edit.EditNameScreen
 import com.github.se.studentconnect.ui.screen.profile.edit.EditNationalityScreen
 import com.github.se.studentconnect.ui.screen.profile.edit.EditProfilePictureScreen
 import com.github.se.studentconnect.ui.screen.search.SearchScreen
-import com.github.se.studentconnect.ui.screen.signup.GetStartedScreen
 import com.github.se.studentconnect.ui.screen.signup.SignUpOrchestrator
+import com.github.se.studentconnect.ui.screen.signup.regularuser.GetStartedScreen
 import com.github.se.studentconnect.ui.screen.visitorProfile.VisitorProfileScreen
 import com.github.se.studentconnect.ui.screen.visitorProfile.VisitorProfileViewModel
 import com.github.se.studentconnect.ui.theme.AppTheme

--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/SignUpOrchestrator.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/SignUpOrchestrator.kt
@@ -1,6 +1,7 @@
 package com.github.se.studentconnect.ui.screen.signup
 
 import android.net.Uri
+import android.util.Log
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -14,6 +15,13 @@ import com.github.se.studentconnect.model.User
 import com.github.se.studentconnect.model.media.MediaRepositoryProvider
 import com.github.se.studentconnect.repository.UserRepository
 import com.github.se.studentconnect.ui.components.BirthdayFormatter
+import com.github.se.studentconnect.ui.screen.signup.regularuser.AddPictureScreen
+import com.github.se.studentconnect.ui.screen.signup.regularuser.BasicInfoScreen
+import com.github.se.studentconnect.ui.screen.signup.regularuser.DescriptionScreen
+import com.github.se.studentconnect.ui.screen.signup.regularuser.ExperiencesScreen
+import com.github.se.studentconnect.ui.screen.signup.regularuser.NationalityScreen
+import com.github.se.studentconnect.ui.screen.signup.regularuser.SignUpStep
+import com.github.se.studentconnect.ui.screen.signup.regularuser.SignUpViewModel
 import com.google.firebase.Timestamp
 import kotlinx.coroutines.launch
 
@@ -130,8 +138,7 @@ fun SignUpOrchestrator(
 
             coroutineScope.launch {
               try {
-                android.util.Log.d(
-                    "SignUpOrchestrator", "Creating user profile for: $firebaseUserId")
+                Log.d("SignUpOrchestrator", "Creating user profile for: $firebaseUserId")
 
                 val profilePictureUrl =
                     uploadProfilePictureIfNeeded(
@@ -153,13 +160,12 @@ fun SignUpOrchestrator(
 
                 // Save user to repository (Firestore in production, local in test mode)
                 userRepository.saveUser(user)
-                android.util.Log.d(
-                    "SignUpOrchestrator", "User profile saved successfully: ${user.userId}")
+                Log.d("SignUpOrchestrator", "User profile saved successfully: ${user.userId}")
 
                 // Notify MainActivity that onboarding is complete
                 onSignUpComplete(user)
               } catch (e: Exception) {
-                android.util.Log.e("SignUpOrchestrator", "Failed to save user profile", e)
+                Log.e("SignUpOrchestrator", "Failed to save user profile", e)
                 errorMessage = "Failed to save profile: ${e.message}"
               } finally {
                 isSavingUser = false

--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/organization/AccountTypeSelectionScreen.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/organization/AccountTypeSelectionScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.studentconnect.ui.screen.signup
+package com.github.se.studentconnect.ui.screen.signup.organization
 
 import androidx.annotation.StringRes
 import androidx.compose.animation.core.Animatable
@@ -51,6 +51,15 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import com.github.se.studentconnect.R
+import com.github.se.studentconnect.ui.screen.signup.SignUpBackButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpLargeSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpMediumSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpPrimaryButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpScreenConstants
+import com.github.se.studentconnect.ui.screen.signup.SignUpSmallSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpSubtitle
+import com.github.se.studentconnect.ui.screen.signup.SignUpTitle
+import com.github.se.studentconnect.ui.screen.signup.regularuser.SignUpViewModel
 import kotlinx.coroutines.delay
 
 /**

--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/organization/BrandOrganizationScreen.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/organization/BrandOrganizationScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.studentconnect.ui.screen.signup
+package com.github.se.studentconnect.ui.screen.signup.organization
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -17,6 +17,15 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.github.se.studentconnect.R
 import com.github.se.studentconnect.ui.eventcreation.FormTextField
+import com.github.se.studentconnect.ui.screen.signup.SignUpBackButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpLargeSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpMediumSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpPrimaryButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpScreenConstants
+import com.github.se.studentconnect.ui.screen.signup.SignUpSkipButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpSmallSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpSubtitle
+import com.github.se.studentconnect.ui.screen.signup.SignUpTitle
 
 /**
  * Composable for a social link input field with optional leading icon.

--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/organization/OrganizationDescriptionScreen.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/organization/OrganizationDescriptionScreen.kt
@@ -1,9 +1,13 @@
-package com.github.se.studentconnect.ui.screen.signup
+package com.github.se.studentconnect.ui.screen.signup.organization
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.github.se.studentconnect.R
 import com.github.se.studentconnect.resources.C
+import com.github.se.studentconnect.ui.screen.signup.regularuser.DescriptionLayout
+import com.github.se.studentconnect.ui.screen.signup.regularuser.DescriptionLayoutCallbacks
+import com.github.se.studentconnect.ui.screen.signup.regularuser.DescriptionLayoutTags
+import com.github.se.studentconnect.ui.screen.signup.regularuser.DescriptionLayoutTextConfig
 
 /** Organization description screen reusing DescriptionLayout to avoid duplication. */
 @Composable

--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/organization/OrganizationInfoScreen.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/organization/OrganizationInfoScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.studentconnect.ui.screen.signup
+package com.github.se.studentconnect.ui.screen.signup.organization
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -27,6 +27,15 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.github.se.studentconnect.R
 import com.github.se.studentconnect.ui.components.TopicFilterChip
+import com.github.se.studentconnect.ui.screen.signup.SignUpBackButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpLargeSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpMediumSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpPrimaryButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpScreenConstants
+import com.github.se.studentconnect.ui.screen.signup.SignUpSmallSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpSubtitle
+import com.github.se.studentconnect.ui.screen.signup.SignUpTitle
+import com.github.se.studentconnect.ui.screen.signup.regularuser.AvatarBanner
 
 object OrganizationInfoScreenTestTags {
   const val SCREEN = "organization_info_screen"
@@ -82,7 +91,8 @@ fun OrganizationInfoScreen(
                   vertical = SignUpScreenConstants.SCREEN_VERTICAL_PADDING),
       horizontalAlignment = Alignment.Start) {
         SignUpBackButton(
-            onClick = onBack, modifier = Modifier.size(SignUpScreenConstants.BACK_BUTTON_SIZE))
+            onClick = onBack,
+            modifier = Modifier.Companion.size(SignUpScreenConstants.BACK_BUTTON_SIZE))
 
         SignUpMediumSpacer()
         SignUpTitle(text = stringResource(R.string.instruction_who_are_you))

--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/organization/OrganizationLogoScreen.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/organization/OrganizationLogoScreen.kt
@@ -1,7 +1,9 @@
-package com.github.se.studentconnect.ui.screen.signup
+package com.github.se.studentconnect.ui.screen.signup.organization
 
 import androidx.compose.runtime.Composable
 import com.github.se.studentconnect.R
+import com.github.se.studentconnect.ui.screen.signup.regularuser.AddPictureScreen
+import com.github.se.studentconnect.ui.screen.signup.regularuser.SignUpViewModel
 
 /**
  * Small wrapper around AddPictureScreen to provide a customized title/subtitle for uploading an

--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/organization/OrganizationProfileSetupScreen.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/organization/OrganizationProfileSetupScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.studentconnect.ui.screen.signup
+package com.github.se.studentconnect.ui.screen.signup.organization
 
 import androidx.annotation.StringRes
 import androidx.compose.animation.animateColorAsState
@@ -34,6 +34,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.disabled
@@ -46,6 +47,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.github.se.studentconnect.R
 import com.github.se.studentconnect.model.Activities
+import com.github.se.studentconnect.ui.screen.signup.SignUpBackButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpLargeSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpPrimaryButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpScreenConstants
+import com.github.se.studentconnect.ui.screen.signup.SignUpSmallSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpTitle
 import com.github.se.studentconnect.ui.theme.AppTheme
 
 private data class SimpleOption(val key: String, @StringRes val labelRes: Int)
@@ -241,7 +248,7 @@ private fun LocationDropdownField(
                     imageVector = Icons.Outlined.Map,
                     contentDescription = stringResource(R.string.content_description_search),
                     tint = primary)
-                Spacer(modifier = Modifier.width(SignUpScreenConstants.ICON_SPACING))
+                Spacer(modifier = Modifier.Companion.width(SignUpScreenConstants.ICON_SPACING))
                 Text(
                     text = displayText ?: placeholder,
                     color =
@@ -321,10 +328,10 @@ private fun SelectableChip(
     selected: Boolean,
     enabled: Boolean = true,
     onClick: () -> Unit,
-    selectedBackgroundColor: androidx.compose.ui.graphics.Color,
-    unselectedBackgroundColor: androidx.compose.ui.graphics.Color,
-    selectedContentColor: androidx.compose.ui.graphics.Color,
-    unselectedContentColor: androidx.compose.ui.graphics.Color,
+    selectedBackgroundColor: Color,
+    unselectedBackgroundColor: Color,
+    selectedContentColor: Color,
+    unselectedContentColor: Color,
     content: @Composable () -> Unit
 ) {
   val primary = MaterialTheme.colorScheme.primary
@@ -376,7 +383,7 @@ private fun DomainChip(
               Icon(
                   imageVector = icon,
                   contentDescription = null,
-                  modifier = Modifier.size(SignUpScreenConstants.ICON_SIZE))
+                  modifier = Modifier.Companion.size(SignUpScreenConstants.ICON_SIZE))
               Text(
                   text = text,
                   style =

--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/organization/TeamRolesScreen.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/organization/TeamRolesScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.studentconnect.ui.screen.signup
+package com.github.se.studentconnect.ui.screen.signup.organization
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalAnimationApi
@@ -42,6 +42,15 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.github.se.studentconnect.R
 import com.github.se.studentconnect.model.organization.OrganizationRole
+import com.github.se.studentconnect.ui.screen.signup.SignUpBackButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpLargeSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpMediumSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpPrimaryButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpScreenConstants
+import com.github.se.studentconnect.ui.screen.signup.SignUpSkipButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpSmallSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpSubtitle
+import com.github.se.studentconnect.ui.screen.signup.SignUpTitle
 import com.github.se.studentconnect.ui.theme.AppTheme
 
 /**
@@ -214,7 +223,9 @@ internal fun TeamRolesContent(
               onRoleDescriptionChange = callbacks.onRoleDescriptionChange,
               onAddRole = callbacks.onAddRole)
 
-          Spacer(modifier = Modifier.height(SignUpScreenConstants.ROLES_FORM_TO_LIST_SPACING))
+          Spacer(
+              modifier =
+                  Modifier.Companion.height(SignUpScreenConstants.ROLES_FORM_TO_LIST_SPACING))
 
           Text(
               text = stringResource(R.string.team_roles_current_section_title),
@@ -223,7 +234,9 @@ internal fun TeamRolesContent(
                       fontWeight = FontWeight.SemiBold,
                       color = MaterialTheme.colorScheme.onSurface))
 
-          Spacer(modifier = Modifier.height(SignUpScreenConstants.SECTION_TITLE_TO_CONTENT_SPACING))
+          Spacer(
+              modifier =
+                  Modifier.Companion.height(SignUpScreenConstants.SECTION_TITLE_TO_CONTENT_SPACING))
 
           Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
             AnimatedContent(
@@ -250,7 +263,9 @@ internal fun TeamRolesContent(
             }
           }
 
-          Spacer(modifier = Modifier.height(SignUpScreenConstants.SUBTITLE_TO_CONTENT_SPACING))
+          Spacer(
+              modifier =
+                  Modifier.Companion.height(SignUpScreenConstants.SUBTITLE_TO_CONTENT_SPACING))
 
           SignUpPrimaryButton(
               text = stringResource(R.string.button_start_now),
@@ -293,7 +308,9 @@ private fun RolesFormCard(
                     suggestions = suggestions,
                     modifier = Modifier.fillMaxWidth())
 
-                Spacer(modifier = Modifier.height(SignUpScreenConstants.TITLE_TO_SUBTITLE_SPACING))
+                Spacer(
+                    modifier =
+                        Modifier.Companion.height(SignUpScreenConstants.TITLE_TO_SUBTITLE_SPACING))
 
                 Text(
                     text = stringResource(R.string.team_roles_name_helper),
@@ -336,7 +353,9 @@ private fun EmptyRolesState(modifier: Modifier = Modifier) {
             textAlign = TextAlign.Center)
 
         Spacer(
-            modifier = Modifier.height(SignUpScreenConstants.EMPTY_STATE_TITLE_TO_SUBTITLE_SPACING))
+            modifier =
+                Modifier.Companion.height(
+                    SignUpScreenConstants.EMPTY_STATE_TITLE_TO_SUBTITLE_SPACING))
 
         Text(
             text = stringResource(R.string.team_roles_empty_state_subtitle),
@@ -465,7 +484,8 @@ private fun RoleCard(
               if (!role.description.isNullOrBlank()) {
                 Spacer(
                     modifier =
-                        Modifier.height(SignUpScreenConstants.ROLE_NAME_TO_DESCRIPTION_SPACING))
+                        Modifier.Companion.height(
+                            SignUpScreenConstants.ROLE_NAME_TO_DESCRIPTION_SPACING))
                 Text(
                     text = role.description,
                     style = MaterialTheme.typography.bodyMedium,
@@ -474,7 +494,8 @@ private fun RoleCard(
 
               Spacer(
                   modifier =
-                      Modifier.height(SignUpScreenConstants.ROLE_DESCRIPTION_TO_BUTTON_SPACING))
+                      Modifier.Companion.height(
+                          SignUpScreenConstants.ROLE_DESCRIPTION_TO_BUTTON_SPACING))
 
               Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                 TextButton(onClick = { onRemoveRole(role) }) {

--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/regularuser/AddPictureScreen.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/regularuser/AddPictureScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.studentconnect.ui.screen.signup
+package com.github.se.studentconnect.ui.screen.signup.regularuser
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
@@ -20,6 +20,15 @@ import androidx.core.net.toUri
 import com.github.se.studentconnect.R
 import com.github.se.studentconnect.ui.components.PicturePickerCard
 import com.github.se.studentconnect.ui.components.PicturePickerStyle
+import com.github.se.studentconnect.ui.screen.signup.SignUpBackButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpLargeSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpMediumSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpPrimaryButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpScreenConstants
+import com.github.se.studentconnect.ui.screen.signup.SignUpSkipButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpSmallSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpSubtitle
+import com.github.se.studentconnect.ui.screen.signup.SignUpTitle
 
 val DEFAULT_PLACEHOLDER = "ic_user".toUri()
 

--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/regularuser/BasicInfoScreen.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/regularuser/BasicInfoScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.studentconnect.ui.screen.signup
+package com.github.se.studentconnect.ui.screen.signup.regularuser
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.BorderStroke
@@ -52,6 +52,14 @@ import com.github.se.studentconnect.R
 import com.github.se.studentconnect.repository.UserRepository
 import com.github.se.studentconnect.ui.components.BirthdayFormatter
 import com.github.se.studentconnect.ui.components.BirthdayPickerDialog
+import com.github.se.studentconnect.ui.screen.signup.SignUpBackButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpLargeSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpMediumSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpPrimaryButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpScreenConstants
+import com.github.se.studentconnect.ui.screen.signup.SignUpSmallSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpSubtitle
+import com.github.se.studentconnect.ui.screen.signup.SignUpTitle
 import com.google.firebase.Timestamp
 import java.util.Date
 import kotlinx.coroutines.delay

--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/regularuser/DescriptionScreen.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/regularuser/DescriptionScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.studentconnect.ui.screen.signup
+package com.github.se.studentconnect.ui.screen.signup.regularuser
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
@@ -22,6 +22,15 @@ import com.github.se.studentconnect.resources.C
 import com.github.se.studentconnect.ui.components.BioTextField
 import com.github.se.studentconnect.ui.components.BioTextFieldConfig
 import com.github.se.studentconnect.ui.components.BioTextFieldStyle
+import com.github.se.studentconnect.ui.screen.signup.SignUpBackButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpLargeSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpMediumSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpPrimaryButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpScreenConstants
+import com.github.se.studentconnect.ui.screen.signup.SignUpSkipButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpSmallSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpSubtitle
+import com.github.se.studentconnect.ui.screen.signup.SignUpTitle
 
 /**
  * Description screen collecting a short multi-line text input from the user. Reuses the
@@ -150,7 +159,9 @@ fun DescriptionLayout(
                             style = BioTextFieldStyle.Bordered))
               }
 
-          Spacer(modifier = Modifier.height(SignUpScreenConstants.SUBTITLE_TO_CONTENT_SPACING))
+          Spacer(
+              modifier =
+                  Modifier.Companion.height(SignUpScreenConstants.SUBTITLE_TO_CONTENT_SPACING))
 
           SignUpPrimaryButton(
               text = stringResource(id = R.string.button_continue),

--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/regularuser/ExperiencesScreen.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/regularuser/ExperiencesScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.studentconnect.ui.screen.signup
+package com.github.se.studentconnect.ui.screen.signup.regularuser
 
 import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.layout.Arrangement
@@ -39,6 +39,11 @@ import com.github.se.studentconnect.R
 import com.github.se.studentconnect.model.Activities
 import com.github.se.studentconnect.resources.C
 import com.github.se.studentconnect.ui.components.TopicChipGrid
+import com.github.se.studentconnect.ui.screen.signup.SignUpBackButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpMediumSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpPrimaryButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpScreenConstants
+import com.github.se.studentconnect.ui.screen.signup.SignUpSubtitle
 import com.github.se.studentconnect.ui.theme.AppTheme
 
 @Composable
@@ -147,7 +152,9 @@ internal fun ExperiencesContent(
                 }
               }
 
-          Spacer(modifier = Modifier.height(SignUpScreenConstants.SUBTITLE_TO_CONTENT_SPACING))
+          Spacer(
+              modifier =
+                  Modifier.Companion.height(SignUpScreenConstants.SUBTITLE_TO_CONTENT_SPACING))
 
           SignUpPrimaryButton(
               text = "Start Now",

--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/regularuser/GetStartedScreen.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/regularuser/GetStartedScreen.kt
@@ -1,6 +1,7 @@
-package com.github.se.studentconnect.ui.screen.signup
+package com.github.se.studentconnect.ui.screen.signup.regularuser
 
 import android.annotation.SuppressLint
+import android.content.Context
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
@@ -75,7 +76,7 @@ fun GetStartedScreen(
     onSignedIn: (String) -> Unit,
     onSignInError: (String) -> Unit = {},
     viewModel: GetStartedViewModel = viewModel(),
-    context: android.content.Context = LocalContext.current,
+    context: Context = LocalContext.current,
     credentialManager: CredentialManager = remember(context) { CredentialManager.create(context) }
 ) {
   val uiState by viewModel.uiState.collectAsState()

--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/regularuser/GetStartedViewModel.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/regularuser/GetStartedViewModel.kt
@@ -1,13 +1,16 @@
 // From Bootcamp
 
-package com.github.se.studentconnect.ui.screen.signup
+package com.github.se.studentconnect.ui.screen.signup.regularuser
 
 import android.content.Context
+import android.util.Log
 import androidx.credentials.CredentialManager
 import androidx.credentials.GetCredentialRequest
 import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.GetCredentialException
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.github.se.studentconnect.R
 import com.github.se.studentconnect.model.authentication.AuthRepository
 import com.github.se.studentconnect.model.authentication.AuthRepositoryFirebase
 import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
@@ -65,8 +68,7 @@ class GetStartedViewModel(private val repository: AuthRepository = AuthRepositor
 
   private fun getSignInOptions(context: Context) =
       GetSignInWithGoogleOption.Builder(
-              serverClientId =
-                  context.getString(com.github.se.studentconnect.R.string.default_web_client_id))
+              serverClientId = context.getString(R.string.default_web_client_id))
           .build()
 
   private fun signInRequest(signInOptions: GetSignInWithGoogleOption) =
@@ -108,13 +110,13 @@ class GetStartedViewModel(private val repository: AuthRepository = AuthRepositor
         }
       } catch (e: GetCredentialCancellationException) {
         // User cancelled the sign-in flow
-        android.util.Log.e("GetStartedViewModel", "Sign-in cancelled by user", e)
+        Log.e("GetStartedViewModel", "Sign-in cancelled by user", e)
         _uiState.update {
           it.copy(isLoading = false, errorMsg = "Sign-in cancelled", signedOut = true, user = null)
         }
-      } catch (e: androidx.credentials.exceptions.GetCredentialException) {
+      } catch (e: GetCredentialException) {
         // Other credential errors - usually SHA-1 fingerprint not registered
-        android.util.Log.e("GetStartedViewModel", "Credential error: ${e.javaClass.simpleName}", e)
+        Log.e("GetStartedViewModel", "Credential error: ${e.javaClass.simpleName}", e)
         _uiState.update {
           it.copy(
               isLoading = false,
@@ -125,7 +127,7 @@ class GetStartedViewModel(private val repository: AuthRepository = AuthRepositor
         }
       } catch (e: Exception) {
         // Unexpected errors
-        android.util.Log.e("GetStartedViewModel", "Unexpected error during sign-in", e)
+        Log.e("GetStartedViewModel", "Unexpected error during sign-in", e)
         _uiState.update {
           it.copy(
               isLoading = false,

--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/regularuser/NationalityScreen.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/regularuser/NationalityScreen.kt
@@ -1,4 +1,4 @@
-package com.github.se.studentconnect.ui.screen.signup
+package com.github.se.studentconnect.ui.screen.signup.regularuser
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -25,6 +25,14 @@ import com.github.se.studentconnect.R
 import com.github.se.studentconnect.ui.components.CountryListSurface
 import com.github.se.studentconnect.ui.components.filterCountries
 import com.github.se.studentconnect.ui.components.loadCountries
+import com.github.se.studentconnect.ui.screen.signup.SignUpBackButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpLargeSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpMediumSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpPrimaryButton
+import com.github.se.studentconnect.ui.screen.signup.SignUpScreenConstants
+import com.github.se.studentconnect.ui.screen.signup.SignUpSmallSpacer
+import com.github.se.studentconnect.ui.screen.signup.SignUpSubtitle
+import com.github.se.studentconnect.ui.screen.signup.SignUpTitle
 import com.github.se.studentconnect.ui.theme.AppTheme
 
 @Composable

--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/regularuser/SignUpViewModel.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/signup/regularuser/SignUpViewModel.kt
@@ -1,9 +1,10 @@
-package com.github.se.studentconnect.ui.screen.signup
+package com.github.se.studentconnect.ui.screen.signup.regularuser
 
 import android.net.Uri
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import com.github.se.studentconnect.ui.screen.signup.organization.AccountTypeOption
 import com.google.firebase.Timestamp
 import java.util.Locale
 

--- a/app/src/test/java/com/github/se/studentconnect/ui/eventcreation/FormTextFieldTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/ui/eventcreation/FormTextFieldTest.kt
@@ -5,7 +5,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material3.Icon
-import com.github.se.studentconnect.ui.screen.signup.SocialLinkField
+import com.github.se.studentconnect.ui.screen.signup.organization.SocialLinkField
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before

--- a/app/src/test/java/com/github/se/studentconnect/ui/experiences/ExperiencesScreenTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/ui/experiences/ExperiencesScreenTest.kt
@@ -24,9 +24,9 @@ import com.github.se.studentconnect.resources.C
 import com.github.se.studentconnect.ui.components.TopicChip
 import com.github.se.studentconnect.ui.components.TopicChipGridTestTags
 import com.github.se.studentconnect.ui.components.TopicFilterChip
-import com.github.se.studentconnect.ui.screen.signup.ExperiencesContent
-import com.github.se.studentconnect.ui.screen.signup.ExperiencesScreen
-import com.github.se.studentconnect.ui.screen.signup.PrimaryCtaButton
+import com.github.se.studentconnect.ui.screen.signup.regularuser.ExperiencesContent
+import com.github.se.studentconnect.ui.screen.signup.regularuser.ExperiencesScreen
+import com.github.se.studentconnect.ui.screen.signup.regularuser.PrimaryCtaButton
 import com.github.se.studentconnect.ui.theme.AppTheme
 import org.junit.Assert
 import org.junit.Rule

--- a/app/src/test/java/com/github/se/studentconnect/ui/screen/description/DescriptionScreenTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/ui/screen/description/DescriptionScreenTest.kt
@@ -22,8 +22,8 @@ import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.unit.dp
 import com.github.se.studentconnect.resources.C
-import com.github.se.studentconnect.ui.screen.signup.DescriptionContent
-import com.github.se.studentconnect.ui.screen.signup.DescriptionScreen
+import com.github.se.studentconnect.ui.screen.signup.regularuser.DescriptionContent
+import com.github.se.studentconnect.ui.screen.signup.regularuser.DescriptionScreen
 import com.github.se.studentconnect.ui.theme.AppTheme
 import org.junit.Assert
 import org.junit.Rule

--- a/app/src/test/java/com/github/se/studentconnect/ui/screen/description/OrganizationDescriptionScreenTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/ui/screen/description/OrganizationDescriptionScreenTest.kt
@@ -20,8 +20,8 @@ import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.unit.dp
 import com.github.se.studentconnect.R
 import com.github.se.studentconnect.resources.C
-import com.github.se.studentconnect.ui.screen.signup.OrganizationDescriptionContent
-import com.github.se.studentconnect.ui.screen.signup.OrganizationDescriptionScreen
+import com.github.se.studentconnect.ui.screen.signup.organization.OrganizationDescriptionContent
+import com.github.se.studentconnect.ui.screen.signup.organization.OrganizationDescriptionScreen
 import com.github.se.studentconnect.ui.theme.AppTheme
 import org.junit.Assert
 import org.junit.Rule

--- a/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/AccountTypeSelectionScreenTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/AccountTypeSelectionScreenTest.kt
@@ -5,6 +5,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import com.github.se.studentconnect.R
+import com.github.se.studentconnect.ui.screen.signup.organization.AccountTypeOption
+import com.github.se.studentconnect.ui.screen.signup.organization.AccountTypeSelectionScreen
+import com.github.se.studentconnect.ui.screen.signup.regularuser.SignUpViewModel
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule

--- a/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/AddPictureScreenTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/AddPictureScreenTest.kt
@@ -6,6 +6,8 @@ import androidx.activity.compose.setContent
 import androidx.core.net.toUri
 import com.github.se.studentconnect.model.media.MediaRepository
 import com.github.se.studentconnect.model.media.MediaRepositoryProvider
+import com.github.se.studentconnect.ui.screen.signup.regularuser.AddPictureScreen
+import com.github.se.studentconnect.ui.screen.signup.regularuser.SignUpViewModel
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse

--- a/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/BrandOrganizationScreenTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/BrandOrganizationScreenTest.kt
@@ -2,6 +2,10 @@ package com.github.se.studentconnect.ui.screen.signup
 
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import com.github.se.studentconnect.ui.screen.signup.organization.BrandOrganizationContent
+import com.github.se.studentconnect.ui.screen.signup.organization.BrandOrganizationScreen
+import com.github.se.studentconnect.ui.screen.signup.organization.SocialLinkField
+import com.github.se.studentconnect.ui.screen.signup.regularuser.SignUpViewModel
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before

--- a/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/GetStartedViewModelTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/GetStartedViewModelTest.kt
@@ -9,6 +9,8 @@ import androidx.credentials.GetCredentialResponse
 import androidx.credentials.exceptions.GetCredentialCancellationException
 import androidx.credentials.exceptions.GetCredentialInterruptedException
 import com.github.se.studentconnect.model.authentication.AuthRepository
+import com.github.se.studentconnect.ui.screen.signup.regularuser.AuthUIState
+import com.github.se.studentconnect.ui.screen.signup.regularuser.GetStartedViewModel
 import com.google.firebase.auth.FirebaseUser
 import io.mockk.coEvery
 import io.mockk.coVerify

--- a/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/NationalityScreenTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/NationalityScreenTest.kt
@@ -5,6 +5,8 @@ import androidx.activity.compose.setContent
 import com.github.se.studentconnect.ui.components.Country
 import com.github.se.studentconnect.ui.components.CountryRow
 import com.github.se.studentconnect.ui.components.loadCountries
+import com.github.se.studentconnect.ui.screen.signup.regularuser.NationalityScreen
+import com.github.se.studentconnect.ui.screen.signup.regularuser.SignUpViewModel
 import com.github.se.studentconnect.ui.theme.AppTheme
 import org.junit.After
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/OrganizationProfileSetupScreenTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/OrganizationProfileSetupScreenTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.github.se.studentconnect.ui.screen.signup.organization.OrganizationProfileSetupScreen
 import com.github.se.studentconnect.ui.theme.AppTheme
 import org.junit.Assert.assertEquals
 import org.junit.Rule

--- a/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/SignUpOrchestratorTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/SignUpOrchestratorTest.kt
@@ -10,6 +10,8 @@ import com.github.se.studentconnect.model.media.MediaRepository
 import com.github.se.studentconnect.model.media.MediaRepositoryProvider
 import com.github.se.studentconnect.repository.UserRepository
 import com.github.se.studentconnect.ui.screen.activities.Invitation
+import com.github.se.studentconnect.ui.screen.signup.regularuser.SignUpStep
+import com.github.se.studentconnect.ui.screen.signup.regularuser.SignUpViewModel
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame

--- a/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/SignUpViewModelTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/SignUpViewModelTest.kt
@@ -1,6 +1,9 @@
 package com.github.se.studentconnect.ui.screen.signup
 
 import androidx.core.net.toUri
+import com.github.se.studentconnect.ui.screen.signup.regularuser.SignUpState
+import com.github.se.studentconnect.ui.screen.signup.regularuser.SignUpStep
+import com.github.se.studentconnect.ui.screen.signup.regularuser.SignUpViewModel
 import com.google.firebase.Timestamp
 import java.util.Date
 import org.junit.Assert.*

--- a/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/TeamRolesScreenTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/TeamRolesScreenTest.kt
@@ -1,6 +1,7 @@
 package com.github.se.studentconnect.ui.screen.signup
 
 import androidx.activity.ComponentActivity
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
@@ -11,6 +12,10 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.github.se.studentconnect.R
 import com.github.se.studentconnect.model.organization.OrganizationRole
+import com.github.se.studentconnect.ui.screen.signup.organization.TeamRolesCallbacks
+import com.github.se.studentconnect.ui.screen.signup.organization.TeamRolesContent
+import com.github.se.studentconnect.ui.screen.signup.organization.TeamRolesScreenWithLocalState
+import com.github.se.studentconnect.ui.screen.signup.organization.TeamRolesState
 import com.github.se.studentconnect.ui.theme.AppTheme
 import org.junit.Assert
 import org.junit.Rule
@@ -91,7 +96,7 @@ class TeamRolesScreenTest {
                     onBackClick = {},
                     onSkipClick = {},
                     onContinueClick = {}),
-            modifier = androidx.compose.ui.Modifier)
+            modifier = Modifier)
       }
     }
 
@@ -118,7 +123,7 @@ class TeamRolesScreenTest {
                     onBackClick = {},
                     onSkipClick = {},
                     onContinueClick = {}),
-            modifier = androidx.compose.ui.Modifier)
+            modifier = Modifier)
       }
     }
 
@@ -148,7 +153,7 @@ class TeamRolesScreenTest {
                     onBackClick = {},
                     onSkipClick = {},
                     onContinueClick = {}),
-            modifier = androidx.compose.ui.Modifier)
+            modifier = Modifier)
       }
     }
 
@@ -187,7 +192,7 @@ class TeamRolesScreenTest {
                     onBackClick = {},
                     onSkipClick = {},
                     onContinueClick = {}),
-            modifier = androidx.compose.ui.Modifier)
+            modifier = Modifier)
       }
     }
 
@@ -223,7 +228,7 @@ class TeamRolesScreenTest {
                     onBackClick = {},
                     onSkipClick = {},
                     onContinueClick = {}),
-            modifier = androidx.compose.ui.Modifier)
+            modifier = Modifier)
       }
     }
 
@@ -262,7 +267,7 @@ class TeamRolesScreenTest {
                     onBackClick = {},
                     onSkipClick = {},
                     onContinueClick = {}),
-            modifier = androidx.compose.ui.Modifier)
+            modifier = Modifier)
       }
     }
 
@@ -294,7 +299,7 @@ class TeamRolesScreenTest {
                     onBackClick = {},
                     onSkipClick = {},
                     onContinueClick = {}),
-            modifier = androidx.compose.ui.Modifier)
+            modifier = Modifier)
       }
     }
 
@@ -327,7 +332,7 @@ class TeamRolesScreenTest {
                     onBackClick = {},
                     onSkipClick = {},
                     onContinueClick = {}),
-            modifier = androidx.compose.ui.Modifier)
+            modifier = Modifier)
       }
     }
 
@@ -361,7 +366,7 @@ class TeamRolesScreenTest {
                     onBackClick = {},
                     onSkipClick = {},
                     onContinueClick = {}),
-            modifier = androidx.compose.ui.Modifier)
+            modifier = Modifier)
       }
     }
 
@@ -397,7 +402,7 @@ class TeamRolesScreenTest {
                     onBackClick = {},
                     onSkipClick = {},
                     onContinueClick = {}),
-            modifier = androidx.compose.ui.Modifier)
+            modifier = Modifier)
       }
     }
 

--- a/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/UsernameTextFieldTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/ui/screen/signup/UsernameTextFieldTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import com.github.se.studentconnect.model.User
 import com.github.se.studentconnect.repository.UserRepository
 import com.github.se.studentconnect.repository.UserRepositoryLocal
+import com.github.se.studentconnect.ui.screen.signup.regularuser.UsernameTextField
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule

--- a/app/src/test/java/com/github/se/studentconnect/ui/signup/OrganizationInfoScreenTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/ui/signup/OrganizationInfoScreenTest.kt
@@ -10,8 +10,8 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import com.github.se.studentconnect.R
-import com.github.se.studentconnect.ui.screen.signup.OrganizationInfoScreen
-import com.github.se.studentconnect.ui.screen.signup.OrganizationInfoScreenTestTags
+import com.github.se.studentconnect.ui.screen.signup.organization.OrganizationInfoScreen
+import com.github.se.studentconnect.ui.screen.signup.organization.OrganizationInfoScreenTestTags
 import com.github.se.studentconnect.ui.theme.AppTheme
 import org.junit.Assert
 import org.junit.Rule


### PR DESCRIPTION
fixes #250

### What
Moved sign-up screens into specific subpackages (e.g., `RegularUser`, `organization`).

### Why
To improve project structure and readability as the sign-up module grows with new organization features.

### How
Refactored the file directory structure and updated package declarations/imports for 36 files.