### PR TITLE
fix: remove Sonar shallow clone warning

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -4,7 +4,13 @@ description: Setup JDK, cache Gradle packages, and make gradlew executable
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
+    - name: Ensure repository is checked out
+      shell: bash
+      run: |
+        if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+          echo "::error::Missing repository checkout. Please call 'actions/checkout' before this action."
+          exit 1
+        fi
 
     - name: Setup JDK
       uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,15 +400,14 @@ jobs:
     needs: [static-checks, unit-tests, build-test-apks, connected-tests]
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-gradle
-
-      # Replace the current shallow clone with a full one
+      # Do a full clone, not a shallow one
       - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of Sonar analysis
+
+      - uses: ./.github/actions/setup-gradle
 
       - name: Cache SonarQube packages
         uses: actions/cache@v4


### PR DESCRIPTION
## What?

Fix the Sonar shallow clone warning.

## Why?

To remove the warning.

## How?

By using a single checkout instead of overriding checkouts in the CI.