### PR TITLE
refactor(model): rename Organization to OrganizationProfile

### DIFF
--- a/app/src/main/java/com/github/se/studentconnect/model/OrganizationProfile.kt
+++ b/app/src/main/java/com/github/se/studentconnect/model/OrganizationProfile.kt
@@ -11,7 +11,7 @@ package com.github.se.studentconnect.model
  * @property events List of events associated with this organization.
  * @property members List of members in this organization.
  */
-data class Organization(
+data class OrganizationProfile(
     val organizationId: String,
     val name: String,
     val description: String,

--- a/app/src/main/java/com/github/se/studentconnect/ui/profile/OrganizationProfileViewModel.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/profile/OrganizationProfileViewModel.kt
@@ -1,9 +1,9 @@
 package com.github.se.studentconnect.ui.profile
 
 import androidx.lifecycle.ViewModel
-import com.github.se.studentconnect.model.Organization
 import com.github.se.studentconnect.model.OrganizationEvent
 import com.github.se.studentconnect.model.OrganizationMember
+import com.github.se.studentconnect.model.OrganizationProfile
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -16,7 +16,7 @@ enum class OrganizationTab {
 
 /** UI state for the organization profile screen. */
 data class OrganizationProfileUiState(
-    val organization: Organization? = null,
+    val organization: OrganizationProfile? = null,
     val selectedTab: OrganizationTab = OrganizationTab.EVENTS,
     val isLoading: Boolean = false,
     val error: String? = null
@@ -71,7 +71,7 @@ class OrganizationProfileViewModel(private val organizationId: String? = null) :
   }
 
   /** Creates mock organization data for testing and preview. */
-  private fun createMockOrganization(): Organization {
+  private fun createMockOrganization(): OrganizationProfile {
     val mockEvents =
         listOf(
             OrganizationEvent(
@@ -104,7 +104,7 @@ class OrganizationProfileViewModel(private val organizationId: String? = null) :
             OrganizationMember(
                 memberId = "member_6", name = "Habibi", role = "Owner", avatarUrl = "avatar_23"))
 
-    return Organization(
+    return OrganizationProfile(
         organizationId = organizationId ?: "org_evolve",
         name = "Evolve",
         description =

--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/profile/OrganizationProfileScreen.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/profile/OrganizationProfileScreen.kt
@@ -60,9 +60,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.se.studentconnect.R
-import com.github.se.studentconnect.model.Organization
 import com.github.se.studentconnect.model.OrganizationEvent
 import com.github.se.studentconnect.model.OrganizationMember
+import com.github.se.studentconnect.model.OrganizationProfile
 import com.github.se.studentconnect.resources.C
 import com.github.se.studentconnect.ui.profile.OrganizationProfileViewModel
 import com.github.se.studentconnect.ui.profile.OrganizationProfileViewModel.Companion.AVATAR_BANNER_HEIGHT
@@ -173,7 +173,7 @@ fun OrganizationProfileScreen(
  */
 @Composable
 private fun OrganizationProfileContent(
-    organization: Organization,
+    organization: OrganizationProfile,
     selectedTab: OrganizationTab,
     onTabSelected: (OrganizationTab) -> Unit,
     onFollowClick: () -> Unit,
@@ -286,7 +286,7 @@ private fun AvatarBanner(modifier: Modifier = Modifier) {
  */
 @Composable
 private fun OrganizationInfoBlock(
-    organization: Organization,
+    organization: OrganizationProfile,
     onFollowClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {

--- a/app/src/test/java/com/github/se/studentconnect/model/OrganizationProfileTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/model/OrganizationProfileTest.kt
@@ -3,12 +3,12 @@ package com.github.se.studentconnect.model
 import org.junit.Assert.*
 import org.junit.Test
 
-class OrganizationTest {
+class OrganizationProfileTest {
 
   @Test
-  fun `Organization with valid fields is created successfully`() {
+  fun `OrganizationProfile with valid fields is created successfully`() {
     val organization =
-        Organization(
+        OrganizationProfile(
             organizationId = "org_1", name = "Test Org", description = "A test organization")
 
     assertEquals("org_1", organization.organizationId)
@@ -21,12 +21,12 @@ class OrganizationTest {
   }
 
   @Test
-  fun `Organization with all optional fields is created successfully`() {
+  fun `OrganizationProfile with all optional fields is created successfully`() {
     val events = listOf(OrganizationEvent("e1", "Event 1", "Jan 1", "Title", "Subtitle"))
     val members = listOf(OrganizationMember("m1", "Member 1", "Owner"))
 
     val organization =
-        Organization(
+        OrganizationProfile(
             organizationId = "org_2",
             name = "Full Org",
             description = "Description",
@@ -42,48 +42,50 @@ class OrganizationTest {
   }
 
   @Test(expected = IllegalArgumentException::class)
-  fun `Organization with blank id throws exception`() {
-    Organization(organizationId = "", name = "Test", description = "Desc")
+  fun `OrganizationProfile with blank id throws exception`() {
+    OrganizationProfile(organizationId = "", name = "Test", description = "Desc")
   }
 
   @Test(expected = IllegalArgumentException::class)
-  fun `Organization with blank name throws exception`() {
-    Organization(organizationId = "org_1", name = "", description = "Desc")
+  fun `OrganizationProfile with blank name throws exception`() {
+    OrganizationProfile(organizationId = "org_1", name = "", description = "Desc")
   }
 
   @Test(expected = IllegalArgumentException::class)
-  fun `Organization with blank description throws exception`() {
-    Organization(organizationId = "org_1", name = "Test", description = "")
+  fun `OrganizationProfile with blank description throws exception`() {
+    OrganizationProfile(organizationId = "org_1", name = "Test", description = "")
   }
 
   @Test(expected = IllegalArgumentException::class)
-  fun `Organization with name exceeding 200 characters throws exception`() {
-    Organization(organizationId = "org_1", name = "A".repeat(201), description = "Description")
+  fun `OrganizationProfile with name exceeding 200 characters throws exception`() {
+    OrganizationProfile(
+        organizationId = "org_1", name = "A".repeat(201), description = "Description")
   }
 
   @Test(expected = IllegalArgumentException::class)
-  fun `Organization with description exceeding 1000 characters throws exception`() {
-    Organization(organizationId = "org_1", name = "Test", description = "A".repeat(1001))
+  fun `OrganizationProfile with description exceeding 1000 characters throws exception`() {
+    OrganizationProfile(organizationId = "org_1", name = "Test", description = "A".repeat(1001))
   }
 
   @Test
-  fun `Organization with maximum allowed name length succeeds`() {
+  fun `OrganizationProfile with maximum allowed name length succeeds`() {
     val organization =
-        Organization(organizationId = "org_1", name = "A".repeat(200), description = "Description")
+        OrganizationProfile(
+            organizationId = "org_1", name = "A".repeat(200), description = "Description")
     assertEquals(200, organization.name.length)
   }
 
   @Test
-  fun `Organization with maximum allowed description length succeeds`() {
+  fun `OrganizationProfile with maximum allowed description length succeeds`() {
     val organization =
-        Organization(organizationId = "org_1", name = "Test", description = "A".repeat(1000))
+        OrganizationProfile(organizationId = "org_1", name = "Test", description = "A".repeat(1000))
     assertEquals(1000, organization.description.length)
   }
 
   @Test
-  fun `Organization copy creates correct instance`() {
+  fun `OrganizationProfile copy creates correct instance`() {
     val original =
-        Organization(
+        OrganizationProfile(
             organizationId = "org_1",
             name = "Original",
             description = "Description",
@@ -96,10 +98,10 @@ class OrganizationTest {
   }
 
   @Test
-  fun `Organization equals compares all fields`() {
-    val org1 = Organization("id", "Name", "Desc")
-    val org2 = Organization("id", "Name", "Desc")
-    val org3 = Organization("id2", "Name", "Desc")
+  fun `OrganizationProfile equals compares all fields`() {
+    val org1 = OrganizationProfile("id", "Name", "Desc")
+    val org2 = OrganizationProfile("id", "Name", "Desc")
+    val org3 = OrganizationProfile("id2", "Name", "Desc")
 
     assertEquals(org1, org2)
     assertNotEquals(org1, org3)


### PR DESCRIPTION
fixes #271 
## What
Renamed the UI-facing `Organization` data class to `OrganizationProfile`.

## Why
Resolved confusion and naming collisions caused by having two `Organization` classes.

## How
Updated all references to use `OrganizationProfile` while keeping the repository `Organization` unchanged.
