### PR TITLE
Show invitations in the activities screen

### DIFF
--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/activities/ActivitiesScreen.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/activities/ActivitiesScreen.kt
@@ -16,8 +16,25 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Circle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Image
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -111,6 +128,12 @@ fun ActivitiesScreen(
   val mainItemWidth = screenWidth * 0.85f
   val sidePeekWidth = (screenWidth - mainItemWidth) / 2
   val pagerState = rememberPagerState { carouselItems.size }
+
+  LaunchedEffect(selectedTab, carouselItems.size) {
+    if (pagerState.currentPage >= carouselItems.size) {
+      pagerState.scrollToPage(0)
+    }
+  }
   Scaffold(
       modifier = Modifier.testTag(ActivitiesScreenTestTags.ACTIVITIES_SCREEN),
       topBar = {


### PR DESCRIPTION
## What?

Invitations to private events now show up on the activities screen (this is not a new screen):

<img src="https://github.com/user-attachments/assets/06a2eac5-43ae-4d37-ba45-fbfac373d815" width=40% />

## Why?

So users can accept an invitation.

This is for #264.

## How?

By linking invitations list to the activities screen (very simple).