### PR TITLE
fix(event-on-map): remove older events on map

### DIFF
--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/map/MapViewModel.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/map/MapViewModel.kt
@@ -117,7 +117,8 @@ class MapViewModel(
       try {
         val events = eventRepository.getAllVisibleEvents()
         val currentTime = com.google.firebase.Timestamp.now()
-        val futureEvents = events.filter { it.end?.seconds!! >= currentTime.seconds }
+        val futureEvents =
+            events.filter { event -> event.end?.let { it.seconds >= currentTime.seconds } ?: true }
         val eventsWithLocation = futureEvents.filter { it.location != null }
         android.util.Log.d(
             "MapViewModel",

--- a/app/src/test/java/com/github/se/studentconnect/ui/screen/map/MapViewModelTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/ui/screen/map/MapViewModelTest.kt
@@ -190,6 +190,8 @@ class MapViewModelTest {
 
   @Test
   fun selectEvent_withValidEventUid_updatesSelectedEventAndLocation() = runTest {
+    val now = com.google.firebase.Timestamp.now()
+    val futureEnd = com.google.firebase.Timestamp(now.seconds + 3600, now.nanoseconds)
     val event =
         com.github.se.studentconnect.model.event.Event.Public(
             uid = "event123",
@@ -199,7 +201,8 @@ class MapViewModelTest {
             location =
                 com.github.se.studentconnect.model.location.Location(
                     46.5197, 6.6323, "Test Location"),
-            start = com.google.firebase.Timestamp.now(),
+            start = now,
+            end = futureEnd,
             isFlash = false,
             subtitle = "Test Subtitle")
 
@@ -223,6 +226,8 @@ class MapViewModelTest {
 
   @Test
   fun selectEvent_withNullEventUid_clearsSelection() = runTest {
+    val now = com.google.firebase.Timestamp.now()
+    val futureEnd = com.google.firebase.Timestamp(now.seconds + 3600, now.nanoseconds)
     val event =
         com.github.se.studentconnect.model.event.Event.Public(
             uid = "event123",
@@ -232,7 +237,8 @@ class MapViewModelTest {
             location =
                 com.github.se.studentconnect.model.location.Location(
                     46.5197, 6.6323, "Test Location"),
-            start = com.google.firebase.Timestamp.now(),
+            start = now,
+            end = futureEnd,
             isFlash = false,
             subtitle = "Test Subtitle")
 
@@ -255,6 +261,8 @@ class MapViewModelTest {
 
   @Test
   fun selectEvent_withInvalidEventUid_doesNotSelectEvent() = runTest {
+    val now = com.google.firebase.Timestamp.now()
+    val futureEnd = com.google.firebase.Timestamp(now.seconds + 3600, now.nanoseconds)
     val event =
         com.github.se.studentconnect.model.event.Event.Public(
             uid = "event123",
@@ -264,7 +272,8 @@ class MapViewModelTest {
             location =
                 com.github.se.studentconnect.model.location.Location(
                     46.5197, 6.6323, "Test Location"),
-            start = com.google.firebase.Timestamp.now(),
+            start = now,
+            end = futureEnd,
             isFlash = false,
             subtitle = "Test Subtitle")
 
@@ -284,6 +293,8 @@ class MapViewModelTest {
 
   @Test
   fun selectEvent_withEventWithoutLocation_doesNotSetLocation() = runTest {
+    val now = com.google.firebase.Timestamp.now()
+    val futureEnd = com.google.firebase.Timestamp(now.seconds + 3600, now.nanoseconds)
     val event =
         com.github.se.studentconnect.model.event.Event.Public(
             uid = "event123",
@@ -291,7 +302,8 @@ class MapViewModelTest {
             title = "Test Event",
             description = "Test Description",
             location = null,
-            start = com.google.firebase.Timestamp.now(),
+            start = now,
+            end = futureEnd,
             isFlash = false,
             subtitle = "Test Subtitle")
 
@@ -312,6 +324,8 @@ class MapViewModelTest {
 
   @Test
   fun clearEventSelectionAnimation_resetsShouldAnimateFlag() = runTest {
+    val now = com.google.firebase.Timestamp.now()
+    val futureEnd = com.google.firebase.Timestamp(now.seconds + 3600, now.nanoseconds)
     val event =
         com.github.se.studentconnect.model.event.Event.Public(
             uid = "event123",
@@ -321,7 +335,8 @@ class MapViewModelTest {
             location =
                 com.github.se.studentconnect.model.location.Location(
                     46.5197, 6.6323, "Test Location"),
-            start = com.google.firebase.Timestamp.now(),
+            start = now,
+            end = futureEnd,
             isFlash = false,
             subtitle = "Test Subtitle")
 
@@ -340,6 +355,8 @@ class MapViewModelTest {
 
   @Test
   fun animateToSelectedEvent_withSelectedEventLocation_callsMapViewportStateFlyTo() = runTest {
+    val now = com.google.firebase.Timestamp.now()
+    val futureEnd = com.google.firebase.Timestamp(now.seconds + 3600, now.nanoseconds)
     val event =
         com.github.se.studentconnect.model.event.Event.Public(
             uid = "event123",
@@ -349,7 +366,8 @@ class MapViewModelTest {
             location =
                 com.github.se.studentconnect.model.location.Location(
                     46.5197, 6.6323, "Test Location"),
-            start = com.google.firebase.Timestamp.now(),
+            start = now,
+            end = futureEnd,
             isFlash = false,
             subtitle = "Test Subtitle")
 
@@ -381,6 +399,8 @@ class MapViewModelTest {
 
   @Test
   fun animateToSelectedEvent_usesCorrectZoomLevel() = runTest {
+    val now = com.google.firebase.Timestamp.now()
+    val futureEnd = com.google.firebase.Timestamp(now.seconds + 3600, now.nanoseconds)
     val event =
         com.github.se.studentconnect.model.event.Event.Public(
             uid = "event123",
@@ -390,7 +410,8 @@ class MapViewModelTest {
             location =
                 com.github.se.studentconnect.model.location.Location(
                     46.5197, 6.6323, "Test Location"),
-            start = com.google.firebase.Timestamp.now(),
+            start = now,
+            end = futureEnd,
             isFlash = false,
             subtitle = "Test Subtitle")
 


### PR DESCRIPTION
## **What**

Filters out **past events** from the map by keeping only **future events with valid locations** in the `MapViewModel` before updating the UI state.


# **Why**

Past events were still being displayed on the map, which:

* Cluttered the map view
* Created confusion for users
* Reduced the relevance of displayed information
  Only upcoming events should be visible on the map for clarity and usability.


# **How**

* Retrieved all visible events from the repository
* Filtered events based on their **end timestamp** compared to the current time
* Kept only **future events with non-null locations**
* Updated the map UI state to use the filtered list
* Improved logging to reflect future vs located event counts


### **Linked Issue**

Closes: #274

