### PR TITLE
fix: events without location show on home screen

### DIFF
--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/home/HomeViewModel.kt
@@ -407,7 +407,7 @@ constructor(
 
           val locationMatch =
               if (event.location == null) {
-                filters.location == null
+                filters.location == null || filters.radiusKm >= 100f
               } else {
                 if (filters.location == null) return@filter true
                 val distance = calculateHaversineDistance(event.location!!, filters.location)


### PR DESCRIPTION
# What
With this pr, events without location set are shown on the home screen when no location filter is set.

# Why
When no locations are set, events should still be discoverable by the user.

# How
By making the appearance of events without location in `HomeViewModel.kt` not only dependent on a huge radius from location filter but also on the existence of a location filter.

fixes #278 