### PR TITLE
hotfix: fix import for AuthenticationProvider

### DIFF
--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/camera/CameraModeSelectorViewModel.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/camera/CameraModeSelectorViewModel.kt
@@ -2,8 +2,8 @@ package com.github.se.studentconnect.ui.screen.camera
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.github.se.studentconnect.model.authentication.AuthenticationProvider
 import com.github.se.studentconnect.model.story.StoryRepository
-import com.github.se.studentconnect.repository.AuthenticationProvider
 import com.github.se.studentconnect.ui.components.EventSelectionState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/test/java/com/github/se/studentconnect/ui/screen/camera/CameraModeSelectorViewModelTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/ui/screen/camera/CameraModeSelectorViewModelTest.kt
@@ -1,8 +1,8 @@
 package com.github.se.studentconnect.ui.screen.camera
 
+import com.github.se.studentconnect.model.authentication.AuthenticationProvider
 import com.github.se.studentconnect.model.event.Event
 import com.github.se.studentconnect.model.story.StoryRepository
-import com.github.se.studentconnect.repository.AuthenticationProvider
 import com.github.se.studentconnect.ui.components.EventSelectionState
 import com.google.firebase.Timestamp
 import io.mockk.coEvery


### PR DESCRIPTION
## What?

Fix the import for `AuthenticationProvider`.
This problem arised since #281 was merged after #276, but its CI ran before the merge, giving the illusion that everything was OK. However, if the CI in #281 would have run again, it would have failed.

## Why?

So the code compiles.

## How?

By fixing the import.
