### PR TITLE
hotfix: fix CI crash from already installed APK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,10 @@ jobs:
           script: |
             set -e
 
+            # Uninstall any existing APK
+            adb uninstall "$PACKAGE" || true
+            adb uninstall "$PACKAGE.test" || true
+
             # Install apks on device
             adb install -t "$APP_DEBUG_APK"
             adb install "$APP_DEBUG_TEST_APK"


### PR DESCRIPTION
## What?

Fix the CI crash due to an already installed APK on the emulator, which for some unknown reason has a different signing key.

## Why?

To fix the CI.

## How?

By uninstalling any already existing APK from the android emulator.

