### PR TITLE
Remove option to uninvite friends from private event

### DIFF
--- a/app/src/androidTest/java/com/github/se/studentconnect/ui/event/InviteFriendsDialogTest.kt
+++ b/app/src/androidTest/java/com/github/se/studentconnect/ui/event/InviteFriendsDialogTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.performClick
 import com.github.se.studentconnect.R
 import com.github.se.studentconnect.model.user.User
 import com.github.se.studentconnect.ui.theme.AppTheme
+import org.junit.Assert.assertFalse
 import org.junit.Rule
 import org.junit.Test
 
@@ -115,6 +116,27 @@ class InviteFriendsDialogTest {
     composeTestRule
         .onNodeWithTag(InviteFriendsDialogTestTags.SEND_BUTTON, useUnmergedTree = true)
         .assertIsEnabled()
+  }
+
+  @Test
+  fun initiallyInvitedFriends_areDisabled() {
+    val friend = buildUser("alreadyInvited")
+    var toggled = false
+    val state =
+        EventUiState(
+            friends = listOf(friend),
+            invitedFriendIds = setOf(friend.userId),
+            initialInvitedFriendIds = setOf(friend.userId),
+            isLoadingFriends = false)
+
+    setContent(state, onToggleFriend = { toggled = true })
+
+    composeTestRule
+        .onNodeWithTag(
+            "${InviteFriendsDialogTestTags.FRIEND_CHECKBOX}_${friend.userId}",
+            useUnmergedTree = true)
+        .assertIsNotEnabled()
+    assertFalse(toggled)
   }
 
   @Test

--- a/app/src/main/java/com/github/se/studentconnect/ui/event/InviteFriendsDialog.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/event/InviteFriendsDialog.kt
@@ -80,6 +80,7 @@ fun InviteFriendsDialog(
                 InviteFriendsSection(
                     friends = state.friends,
                     invitedFriendIds = state.invitedFriendIds,
+                    initialInvitedFriendIds = state.initialInvitedFriendIds,
                     isLoadingFriends = state.isLoadingFriends,
                     friendsErrorRes = state.friendsErrorRes,
                     onToggleFriend = onToggleFriend)
@@ -110,6 +111,7 @@ fun InviteFriendsDialog(
 private fun InviteFriendsSection(
     friends: List<User>,
     invitedFriendIds: Set<String>,
+    initialInvitedFriendIds: Set<String>,
     isLoadingFriends: Boolean,
     @StringRes friendsErrorRes: Int?,
     onToggleFriend: (String) -> Unit,
@@ -156,9 +158,11 @@ private fun InviteFriendsSection(
                       color = MaterialTheme.colorScheme.onSurfaceVariant)
                   Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     friends.forEach { friend ->
+                      val isInitiallyInvited = initialInvitedFriendIds.contains(friend.userId)
                       FriendInviteRow(
                           friend = friend,
                           isChecked = invitedFriendIds.contains(friend.userId),
+                          enabled = !isInitiallyInvited,
                           onCheckedChange = { onToggleFriend(friend.userId) })
                     }
                   }
@@ -172,6 +176,7 @@ private fun InviteFriendsSection(
 private fun FriendInviteRow(
     friend: User,
     isChecked: Boolean,
+    enabled: Boolean,
     onCheckedChange: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -182,6 +187,7 @@ private fun FriendInviteRow(
         Checkbox(
             checked = isChecked,
             onCheckedChange = { onCheckedChange() },
+            enabled = enabled,
             modifier =
                 Modifier.testTag("${InviteFriendsDialogTestTags.FRIEND_CHECKBOX}_${friend.userId}"))
         Column(modifier = Modifier.weight(1f)) {

--- a/app/src/test/java/com/github/se/studentconnect/ui/event/EventViewModelTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/ui/event/EventViewModelTest.kt
@@ -710,7 +710,7 @@ class EventViewModelTest {
   }
 
   @Test
-  fun updateInvitationsForEvent_addsAndRemoves() = runTest {
+  fun updateInvitationsForEvent_addsAndKeepsExisting() = runTest {
     val ownerId = AuthenticationProvider.testUserId!!
     val friend1 =
         User(
@@ -751,19 +751,22 @@ class EventViewModelTest {
     vm.showInviteFriendsDialog()
     advanceUntilIdle()
 
-    // Toggle selection: remove friend1, add friend2
+    // Attempt to toggle existing invite should have no effect
     vm.toggleFriendInvitation(friend1.userId)
+    assertTrue(vm.uiState.value.invitedFriendIds.contains(friend1.userId))
+
+    // Add friend2
     vm.toggleFriendInvitation(friend2.userId)
     vm.updateInvitationsForEvent()
     advanceUntilIdle()
 
     val invites = localEventRepo.getEventInvitations(event.uid)
-    assertFalse(invites.contains(friend1.userId))
+    assertTrue(invites.contains(friend1.userId))
     assertTrue(invites.contains(friend2.userId))
     val state = vm.uiState.value
     assertFalse(state.showInviteFriendsDialog)
-    assertEquals(setOf(friend2.userId), state.invitedFriendIds)
-    assertEquals(setOf(friend2.userId), state.initialInvitedFriendIds)
+    assertEquals(setOf(friend1.userId, friend2.userId), state.invitedFriendIds)
+    assertEquals(setOf(friend1.userId, friend2.userId), state.initialInvitedFriendIds)
   }
 
   @Test


### PR DESCRIPTION
## What?

Make it so friends cannot be uninvited from a private event.

The checkboxes look like this when they cannot be unchecked:

<img src="https://github.com/user-attachments/assets/7bfbc168-dabe-4a3c-9a2d-28984eb52395" width=40% />

## Why?

So friends who accept an invite cannot be refused (this is more logical).
Resolves #317.

## How?

By removing the ability to uncheck the box for an already invited friend.
Also remove the feature from the repository.

