### PR TITLE
 Change date display language from French to English in Home Screen

### DIFF
--- a/app/src/main/java/com/github/se/studentconnect/ui/utils/ListOfEvents.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/utils/ListOfEvents.kt
@@ -396,7 +396,7 @@ fun formatDateHeader(timestamp: Timestamp): String {
     eventCalendar.get(Calendar.YEAR) == tomorrow.get(Calendar.YEAR) &&
         eventCalendar.get(Calendar.DAY_OF_YEAR) == tomorrow.get(Calendar.DAY_OF_YEAR) -> "TOMORROW"
     else ->
-        createGregorianFormatter("EEEE d MMMM", Locale.FRENCH)
+        createGregorianFormatter("EEEE d MMMM", Locale.ENGLISH)
             .format(timestamp.toDate())
             .uppercase()
   }


### PR DESCRIPTION
## What

This PR changes the date display format in the Home Screen from French to English. Date headers in the event list will now display dates like "THURSDAY 11 DECEMBER" instead of "JEUDI 11 DÉCEMBRE".

## Why

The application should display dates in English to provide a consistent UX. The previous French locale was causing dates to appear in French, which did not align with the application's language requirements.

## How

The change is implemented by updating the `formatDateHeader` function in `ListOfEvents.kt`:

- Changed the locale parameter from `Locale.FRENCH` to `Locale.ENGLISH` in the `createGregorianFormatter` call (line 399)
- The date format pattern remains the same (`"EEEE d MMMM"`), only the locale has changed
- Special cases for "TODAY" and "TOMORROW" remain unchanged as they are already in English

Fixes #346 

<img width="379" height="767" alt="Capture d’écran 2025-12-11 à 21 10 19" src="https://github.com/user-attachments/assets/138a1fbb-2883-4713-adf6-7e55e503516f" />
