### PR TITLE
refactor(event): run fetchAttendees and pager scroll concurrently

### DIFF
--- a/app/src/main/java/com/github/se/studentconnect/ui/event/EventView.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/event/EventView.kt
@@ -405,10 +405,8 @@ private fun BaseEventView(
                                 event = event,
                                 participantCount = participantCount,
                                 onClick = {
-                                  coroutineScope.launch {
-                                    pagerState.animateScrollToPage(0)
-                                    eventViewModel.fetchAttendees()
-                                  }
+                                  coroutineScope.launch { pagerState.animateScrollToPage(0) }
+                                  coroutineScope.launch { eventViewModel.fetchAttendees() }
                                 })
                           }
                     }


### PR DESCRIPTION
fixes #343 
## What?
Seperate `animateScrollToPage` and `fetchAttendees` in two seperate coroutines

## Why?
Only the scrolling was performed but Attendees were not visible

## How?
Launch animateScrollToPage and fetchAttendees in two separate coroutines instead of one. This decouples the UI animation from the data fetching, ensuring that fetchAttendees is called immediately and does not wait for the scroll animation to suspend and finish.
