### PR TITLE
Fix dark theme for organization on home screen

### DIFF
--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/home/OrganizationSuggestions.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/home/OrganizationSuggestions.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.github.se.studentconnect.R
 import com.github.se.studentconnect.resources.C
-import com.github.se.studentconnect.resources.Variables
 
 private object OrganizationSuggestionsConstants {
   // Section
@@ -120,7 +119,7 @@ private fun OrganizationCard(organization: OrganizationData, onClick: () -> Unit
               .semantics(mergeDescendants = false) {}
               .testTag("${C.Tag.org_suggestions_card}_${organization.id}"),
       shape = RoundedCornerShape(OrganizationSuggestionsConstants.CARD_CORNER_RADIUS_DP.dp),
-      colors = CardDefaults.cardColors(containerColor = Variables.LightGreyBackground),
+      colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
       elevation =
           CardDefaults.cardElevation(
               defaultElevation = OrganizationSuggestionsConstants.CARD_ELEVATION_DP.dp)) {
@@ -142,7 +141,7 @@ private fun OrganizationImage(organizationId: String) {
           Modifier.fillMaxWidth()
               .aspectRatio(OrganizationSuggestionsConstants.IMAGE_ASPECT_RATIO)
               .background(
-                  color = Variables.LightGreyBackground,
+                  color = MaterialTheme.colorScheme.surfaceVariant,
                   shape =
                       RoundedCornerShape(
                           OrganizationSuggestionsConstants.IMAGE_CORNER_RADIUS_DP.dp))


### PR DESCRIPTION
## What?

Fix the dark mode colors of the organization component on the home screen.

<img width="40%" alt="image" src="https://github.com/user-attachments/assets/a47b509e-afca-4c8e-a00a-0b12a07d3e53" />

<img width="40%" alt="image" src="https://github.com/user-attachments/assets/e52c265f-cc39-4b41-a30f-b421440507b9" />

## Why?

The organization component used white mode colors even when in dark mode.

## How?

By using the Material Theme colors which change automatically.

