### PR TITLE
Refresh organization list when creating organization

### DIFF
--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/profile/OrganizationManagementScreen.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/profile/OrganizationManagementScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -55,6 +56,9 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.se.studentconnect.R
 import com.github.se.studentconnect.model.media.MediaRepositoryProvider
@@ -95,6 +99,18 @@ fun OrganizationManagementScreen(
     modifier: Modifier = Modifier
 ) {
   val uiState by viewModel.uiState.collectAsState()
+  val lifecycleOwner = LocalLifecycleOwner.current
+
+  // Reload organizations when returning to this screen (e.g., after creating a new one)
+  DisposableEffect(lifecycleOwner) {
+    val observer = LifecycleEventObserver { _, event ->
+      if (event == Lifecycle.Event.ON_RESUME) {
+        viewModel.loadUserOrganizations()
+      }
+    }
+    lifecycleOwner.lifecycle.addObserver(observer)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+  }
 
   // Check if user should be redirected to organization creation
   LaunchedEffect(uiState.shouldRedirectToCreation) {


### PR DESCRIPTION
## What?

Refresh the organization list after creating an organization.

As can be seen in the video below, the list of organizations is updated when a new one is created.

https://github.com/user-attachments/assets/28002ac5-2539-4f4b-b362-bd1a24e55dce

## Why?

So the organization list is up to date.

## How?

By making the page refresh when navigating back.

