### PR TITLE
Display Event Creator Name in Home Screen Event Cards

### DIFF
--- a/app/src/main/java/com/github/se/studentconnect/ui/event/EventView.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/event/EventView.kt
@@ -512,7 +512,7 @@ private fun EventDetailsContent(params: EventDetailsContentParams) {
                     .testTag(EventViewTestTags.ACTION_BUTTONS_SECTION),
             elevation =
                 CardDefaults.cardElevation(defaultElevation = Dimensions.EventCardElevation),
-            shape = RoundedCornerShape(Dimensions.EventCardCornerRadius),
+            shape = RoundedCornerShape(Dimensions.EvenevetCardCornerRadius),
             colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
               Column(
                   modifier = Modifier.fillMaxWidth().padding(Dimensions.SpacingNormal),

--- a/app/src/main/java/com/github/se/studentconnect/ui/event/EventView.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/event/EventView.kt
@@ -512,7 +512,7 @@ private fun EventDetailsContent(params: EventDetailsContentParams) {
                     .testTag(EventViewTestTags.ACTION_BUTTONS_SECTION),
             elevation =
                 CardDefaults.cardElevation(defaultElevation = Dimensions.EventCardElevation),
-            shape = RoundedCornerShape(Dimensions.EvenevetCardCornerRadius),
+            shape = RoundedCornerShape(Dimensions.EventCardCornerRadius),
             colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
               Column(
                   modifier = Modifier.fillMaxWidth().padding(Dimensions.SpacingNormal),

--- a/app/src/main/java/com/github/se/studentconnect/ui/theme/Dimensions.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/theme/Dimensions.kt
@@ -65,4 +65,19 @@ object Dimensions {
   val EventDividerPadding = 8.dp
   val EventPollCardPadding = 8.dp
   val EventPollCardSpacing = 4.dp
+
+  // Event Card specific (for list views)
+  val EventCardImageHeight = 180.dp
+  val EventCardBottomPadding = 16.dp
+  val EventCardContentPadding = 16.dp
+  val EventCardFavoriteButtonSize = 36.dp
+  val EventCardFavoriteButtonPadding = 8.dp
+  val EventCardChipCornerRadius = 8.dp
+  val EventCardChipHorizontalPadding = 10.dp
+  val EventCardChipVerticalPadding = 5.dp
+  val EventCardTagSpacing = 8.dp
+  val LiveBadgeHorizontalPadding = 10.dp
+  val LiveBadgeVerticalPadding = 5.dp
+  val LiveBadgeIconSize = 8.dp
+  val LiveBadgeSpacerWidth = 6.dp
 }

--- a/app/src/main/java/com/github/se/studentconnect/ui/utils/ListOfEvents.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/utils/ListOfEvents.kt
@@ -260,35 +260,32 @@ fun EventCard(
 
   // Fetch user creator (for personal events)
   val creator by
-      produceState<User?>(
-          initialValue = null, event.ownerId, event.organizationId) {
-            // Only fetch user if it's not an organization event
-            if (event.organizationId == null) {
-              value =
-                  runCatching { userRepository.getUserById(event.ownerId) }
-                      .onFailure {
-                        Log.e("EventCard", "Failed to fetch creator for event ${event.uid}", it)
-                      }
-                      .getOrNull()
-            } else {
-              value = null
-            }
-          }
+      produceState<User?>(initialValue = null, event.ownerId, event.organizationId) {
+        // Only fetch user if it's not an organization event
+        if (event.organizationId == null) {
+          value =
+              runCatching { userRepository.getUserById(event.ownerId) }
+                  .onFailure {
+                    Log.e("EventCard", "Failed to fetch creator for event ${event.uid}", it)
+                  }
+                  .getOrNull()
+        } else {
+          value = null
+        }
+      }
 
   // Fetch organization creator (for organization events)
   val organization by
-      produceState<Organization?>(
-          initialValue = null, event.organizationId) {
-            value =
-                event.organizationId?.let { orgId ->
-                  runCatching { organizationRepository.getOrganizationById(orgId) }
-                      .onFailure {
-                        Log.e(
-                            "EventCard", "Failed to fetch organization for event ${event.uid}", it)
-                      }
-                      .getOrNull()
-                }
-          }
+      produceState<Organization?>(initialValue = null, event.organizationId) {
+        value =
+            event.organizationId?.let { orgId ->
+              runCatching { organizationRepository.getOrganizationById(orgId) }
+                  .onFailure {
+                    Log.e("EventCard", "Failed to fetch organization for event ${event.uid}", it)
+                  }
+                  .getOrNull()
+            }
+      }
   Card(
       onClick = onClick,
       modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp).testTag("event_card_${event.uid}"),

--- a/app/src/main/java/com/github/se/studentconnect/ui/utils/ListOfEvents.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/utils/ListOfEvents.kt
@@ -41,6 +41,7 @@ import com.github.se.studentconnect.resources.C
 import com.github.se.studentconnect.ui.navigation.Route
 import com.github.se.studentconnect.ui.screen.home.OrganizationData
 import com.github.se.studentconnect.ui.screen.home.OrganizationSuggestions
+import com.github.se.studentconnect.ui.theme.Dimensions
 import com.google.firebase.Timestamp
 import java.text.SimpleDateFormat
 import java.util.Calendar

--- a/app/src/main/java/com/github/se/studentconnect/ui/utils/ListOfEvents.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/utils/ListOfEvents.kt
@@ -35,7 +35,9 @@ import androidx.navigation.NavHostController
 import com.github.se.studentconnect.R
 import com.github.se.studentconnect.model.event.Event
 import com.github.se.studentconnect.model.media.MediaRepositoryProvider
+import com.github.se.studentconnect.model.organization.Organization
 import com.github.se.studentconnect.model.organization.OrganizationRepositoryProvider
+import com.github.se.studentconnect.model.user.User
 import com.github.se.studentconnect.model.user.UserRepositoryProvider
 import com.github.se.studentconnect.resources.C
 import com.github.se.studentconnect.ui.navigation.Route
@@ -258,7 +260,7 @@ fun EventCard(
 
   // Fetch user creator (for personal events)
   val creator by
-      produceState<com.github.se.studentconnect.model.user.User?>(
+      produceState<User?>(
           initialValue = null, event.ownerId, event.organizationId) {
             // Only fetch user if it's not an organization event
             if (event.organizationId == null) {
@@ -275,7 +277,7 @@ fun EventCard(
 
   // Fetch organization creator (for organization events)
   val organization by
-      produceState<com.github.se.studentconnect.model.organization.Organization?>(
+      produceState<Organization?>(
           initialValue = null, event.organizationId) {
             value =
                 event.organizationId?.let { orgId ->

--- a/app/src/main/java/com/github/se/studentconnect/ui/utils/ListOfEvents.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/utils/ListOfEvents.kt
@@ -35,6 +35,7 @@ import androidx.navigation.NavHostController
 import com.github.se.studentconnect.R
 import com.github.se.studentconnect.model.event.Event
 import com.github.se.studentconnect.model.media.MediaRepositoryProvider
+import com.github.se.studentconnect.model.organization.OrganizationRepositoryProvider
 import com.github.se.studentconnect.model.user.UserRepositoryProvider
 import com.github.se.studentconnect.resources.C
 import com.github.se.studentconnect.ui.navigation.Route
@@ -84,14 +85,16 @@ fun LiveEventBadge(isLive: Boolean, isFlash: Boolean, modifier: Modifier = Modif
                 .background(
                     MaterialTheme.colorScheme.error.copy(alpha = C.FlashEvent.BADGE_ALPHA),
                     shape = CircleShape)
-                .padding(horizontal = 10.dp, vertical = 5.dp),
+                .padding(
+                    horizontal = Dimensions.LiveBadgeHorizontalPadding,
+                    vertical = Dimensions.LiveBadgeVerticalPadding),
         verticalAlignment = Alignment.CenterVertically) {
           Icon(
               imageVector = Icons.Filled.Circle,
               contentDescription = stringResource(R.string.content_description_live_icon),
               tint = MaterialTheme.colorScheme.onError,
-              modifier = Modifier.size(8.dp))
-          Spacer(modifier = Modifier.width(6.dp))
+              modifier = Modifier.size(Dimensions.LiveBadgeIconSize))
+          Spacer(modifier = Modifier.width(Dimensions.LiveBadgeSpacerWidth))
           Text(
               text = stringResource(R.string.event_label_live),
               color = MaterialTheme.colorScheme.onError,
@@ -147,9 +150,12 @@ fun EventListScreen(
     organizationSuggestionsConfig: OrganizationSuggestionsConfig = OrganizationSuggestionsConfig()
 ) {
   if (events.isEmpty()) {
-    Box(modifier = Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.Center) {
-      Text("No events found matching your criteria.", style = MaterialTheme.typography.bodyLarge)
-    }
+    Box(
+        modifier = Modifier.fillMaxSize().padding(Dimensions.SpacingNormal),
+        contentAlignment = Alignment.Center) {
+          Text(
+              "No events found matching your criteria.", style = MaterialTheme.typography.bodyLarge)
+        }
     return
   }
 
@@ -171,7 +177,12 @@ fun EventListScreen(
   LazyColumn(
       state = listState,
       modifier = Modifier.fillMaxSize().testTag("event_list"),
-      contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 16.dp)) {
+      contentPadding =
+          PaddingValues(
+              start = Dimensions.SpacingNormal,
+              end = Dimensions.SpacingNormal,
+              top = Dimensions.SpacingNormal,
+              bottom = Dimensions.SpacingNormal)) {
         topContent?.let { header -> item(key = "event_list_header") { header() } }
 
         groupedEvents.entries.forEachIndexed { index, (dateHeader, eventsOnDate) ->
@@ -198,7 +209,7 @@ fun EventListScreen(
               OrganizationSuggestions(
                   organizations = organizationSuggestionsConfig.organizations,
                   onOrganizationClick = organizationSuggestionsConfig.onOrganizationClick,
-                  modifier = Modifier.padding(vertical = 16.dp))
+                  modifier = Modifier.padding(vertical = Dimensions.SpacingNormal))
             }
           }
         }
@@ -242,17 +253,39 @@ fun EventCard(
 
   // Fetch event creator information
   val userRepository = UserRepositoryProvider.repository
-  val creator by
-  produceState<com.github.se.studentconnect.model.user.User?>(
-      initialValue = null, event.ownerId) {
-      value =
-          runCatching { userRepository.getUserById(event.ownerId) }
-              .onFailure {
-                  Log.e("EventCard", "Failed to fetch creator for event ${event.uid}", it)
-              }
-              .getOrNull()
-  }
+  val organizationRepository = OrganizationRepositoryProvider.repository
 
+  // Fetch user creator (for personal events)
+  val creator by
+      produceState<com.github.se.studentconnect.model.user.User?>(
+          initialValue = null, event.ownerId, event.organizationId) {
+            // Only fetch user if it's not an organization event
+            if (event.organizationId == null) {
+              value =
+                  runCatching { userRepository.getUserById(event.ownerId) }
+                      .onFailure {
+                        Log.e("EventCard", "Failed to fetch creator for event ${event.uid}", it)
+                      }
+                      .getOrNull()
+            } else {
+              value = null
+            }
+          }
+
+  // Fetch organization creator (for organization events)
+  val organization by
+      produceState<com.github.se.studentconnect.model.organization.Organization?>(
+          initialValue = null, event.organizationId) {
+            value =
+                event.organizationId?.let { orgId ->
+                  runCatching { organizationRepository.getOrganizationById(orgId) }
+                      .onFailure {
+                        Log.e(
+                            "EventCard", "Failed to fetch organization for event ${event.uid}", it)
+                      }
+                      .getOrNull()
+                }
+          }
   Card(
       onClick = onClick,
       modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp).testTag("event_card_${event.uid}"),
@@ -261,7 +294,7 @@ fun EventCard(
       colors =
           CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)) {
         Column(modifier = Modifier.fillMaxWidth()) {
-          Box(modifier = Modifier.fillMaxWidth().height(180.dp)) {
+          Box(modifier = Modifier.fillMaxWidth().height(Dimensions.EventCardImageHeight)) {
             if (imageBitmap != null) {
               Image(
                   bitmap = imageBitmap!!,
@@ -269,7 +302,10 @@ fun EventCard(
                       stringResource(R.string.content_description_event_card_picture),
                   modifier =
                       Modifier.fillMaxSize()
-                          .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)),
+                          .clip(
+                              RoundedCornerShape(
+                                  topStart = Dimensions.EventCardCornerRadius,
+                                  topEnd = Dimensions.EventCardCornerRadius)),
                   contentScale = ContentScale.Crop)
             } else {
               Image(
@@ -277,7 +313,10 @@ fun EventCard(
                   contentDescription = event.title,
                   modifier =
                       Modifier.fillMaxSize()
-                          .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)),
+                          .clip(
+                              RoundedCornerShape(
+                                  topStart = Dimensions.EventCardCornerRadius,
+                                  topEnd = Dimensions.EventCardCornerRadius)),
                   contentScale = ContentScale.Crop)
             }
 
@@ -310,7 +349,7 @@ fun EventCard(
                     Modifier.align(Alignment.TopStart)
                         .padding(C.FlashEvent.BADGE_OUTER_PADDING_DP.dp))
           }
-          Column(modifier = Modifier.padding(16.dp)) {
+          Column(modifier = Modifier.padding(Dimensions.EventCardContentPadding)) {
             Text(
                 text = event.title,
                 style = MaterialTheme.typography.headlineSmall,
@@ -326,16 +365,26 @@ fun EventCard(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = MAX_LINES_FOR_ADDRESS_TEXT,
                 overflow = TextOverflow.Ellipsis)
-            creator?.let { user ->
+            // Display organization name if it's an organization event, otherwise display user name
+            organization?.let { org ->
               Spacer(modifier = Modifier.height(4.dp))
               Text(
-                  text =
-                      stringResource(R.string.text_event_creator_by, user.firstName, user.lastName),
+                  text = "by ${org.name}",
                   style = MaterialTheme.typography.bodySmall,
                   color = MaterialTheme.colorScheme.onSurfaceVariant,
                   modifier = Modifier.testTag("event_card_creator_${event.uid}"))
             }
-            Spacer(modifier = Modifier.height(12.dp))
+                ?: creator?.let { user ->
+                  Spacer(modifier = Modifier.height(4.dp))
+                  Text(
+                      text =
+                          stringResource(
+                              R.string.text_event_creator_by, user.firstName, user.lastName),
+                      style = MaterialTheme.typography.bodySmall,
+                      color = MaterialTheme.colorScheme.onSurfaceVariant,
+                      modifier = Modifier.testTag("event_card_creator_${event.uid}"))
+                }
+            Spacer(modifier = Modifier.height(Dimensions.SpacingMedium))
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
@@ -354,7 +403,7 @@ fun EventCard(
                       color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             if (event is Event.Public && event.tags.isNotEmpty()) {
-              Spacer(modifier = Modifier.height(12.dp))
+              Spacer(modifier = Modifier.height(Dimensions.SpacingMedium))
               Row(
                   horizontalArrangement = Arrangement.spacedBy(8.dp),
                   modifier = Modifier.fillMaxWidth()) {
@@ -372,8 +421,10 @@ fun Chip(tag: String) {
       modifier =
           Modifier.background(
                   color = MaterialTheme.colorScheme.surfaceVariant,
-                  shape = RoundedCornerShape(8.dp))
-              .padding(horizontal = 10.dp, vertical = 5.dp)) {
+                  shape = RoundedCornerShape(Dimensions.EventCardChipCornerRadius))
+              .padding(
+                  horizontal = Dimensions.EventCardChipHorizontalPadding,
+                  vertical = Dimensions.EventCardChipVerticalPadding)) {
         Text(
             text = tag.uppercase(),
             color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/app/src/main/java/com/github/se/studentconnect/ui/utils/ListOfEvents.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/utils/ListOfEvents.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import com.github.se.studentconnect.R
 import com.github.se.studentconnect.model.event.Event
-import com.github.se.studentconnect.model.media.MediaRepositoryProvider
 import com.github.se.studentconnect.model.organization.Organization
 import com.github.se.studentconnect.model.organization.OrganizationRepositoryProvider
 import com.github.se.studentconnect.model.user.User
@@ -51,7 +50,6 @@ import java.util.Date
 import java.util.GregorianCalendar
 import java.util.Locale
 import kotlin.random.Random
-import kotlinx.coroutines.Dispatchers
 
 /**
  * Shared composable for displaying live event badge (flash icon or LIVE text). This eliminates code

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -213,6 +213,7 @@
     <string name="text_no_new_invitations">No new invitations</string>
     <string name="text_no_past_events">No past events</string>
     <string name="text_participants_count">%d participants</string>
+    <string name="text_event_creator_by">by %1$s %2$s</string>
     <string name="text_empty_upcoming_description">You haven\'t joined any events yet. Explore to find some!</string>
     <string name="text_empty_invitations_description">You have no new event invitations at the moment.</string>
     <string name="text_empty_past_description">Events you have attended will appear here.</string>


### PR DESCRIPTION
## What?

Adds event creator name display to event cards on the home screen, showing "by [First name] [Last name]" or "[Organization name]" for each event.

## Why?

Event cards currently don't show who created the event, making it difficult for users to identify events from people they know or trust.

## How?

Added string resource and modified `EventCard` to fetch and display creator information asynchronously using `UserRepositoryProvider`.


Fixes #391

<img width="261" height="217" alt="Capture d’écran 2025-12-16 à 23 29 54" src="https://github.com/user-attachments/assets/333e72c8-d21e-42ed-90dc-ec386ab85939" />
