### PR TITLE
Revert "fix(ci): remove scheduling worker to fix out of memory error"

### DIFF
--- a/app/src/main/java/com/github/se/studentconnect/MainActivity.kt
+++ b/app/src/main/java/com/github/se/studentconnect/MainActivity.kt
@@ -21,9 +21,13 @@ import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.*
 import androidx.navigation.navArgument
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
 import com.github.se.studentconnect.model.user.UserRepository
 import com.github.se.studentconnect.model.user.UserRepositoryProvider
 import com.github.se.studentconnect.resources.C
+import com.github.se.studentconnect.service.EventReminderWorker
 import com.github.se.studentconnect.service.NotificationChannelManager
 import com.github.se.studentconnect.ui.activities.EventView
 import com.github.se.studentconnect.ui.eventcreation.CreatePrivateEventScreen
@@ -61,6 +65,7 @@ import com.github.se.studentconnect.ui.screen.visitorprofile.VisitorProfileViewM
 import com.github.se.studentconnect.ui.theme.AppTheme
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
+import java.util.concurrent.TimeUnit
 import okhttp3.OkHttpClient
 
 /**
@@ -79,15 +84,13 @@ class MainActivity : ComponentActivity() {
     // Initialize notification channels
     NotificationChannelManager.createNotificationChannels(this)
 
-    // DISABLED: Schedule periodic event reminder worker (runs every 15 minutes)
-    // This worker has been disabled to prevent OutOfMemoryError in CI environments.
-    // Notifications are still handled via FCM push notifications and other mechanisms.
-    // val eventReminderRequest =
-    //     PeriodicWorkRequestBuilder<EventReminderWorker>(15, TimeUnit.MINUTES).build()
-    //
-    // WorkManager.getInstance(this)
-    //     .enqueueUniquePeriodicWork(
-    //         "event_reminder_work", ExistingPeriodicWorkPolicy.KEEP, eventReminderRequest)
+    // Schedule periodic event reminder worker (runs every 15 minutes)
+    val eventReminderRequest =
+        PeriodicWorkRequestBuilder<EventReminderWorker>(15, TimeUnit.MINUTES).build()
+
+    WorkManager.getInstance(this)
+        .enqueueUniquePeriodicWork(
+            "event_reminder_work", ExistingPeriodicWorkPolicy.KEEP, eventReminderRequest)
 
     setContent {
       AppTheme {


### PR DESCRIPTION
Reverts StudentConnect-SwEnt/StudentConnect#395

Since out of memory problems from the unit tests are persisting, I reverted this fix since it didn't work.