### PR TITLE
Put unit tests on blacksmith

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           path: app/build/reports/lint-*
 
   unit-tests:
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-gradle


### PR DESCRIPTION
## What?

Put unit tests in the CI on blacksmith runners.

## Why?

To speed them up and get more memory.

## How?

By changing the runner.

