### PR TITLE
Feat/event at top of list after pin

### DIFF
--- a/app/src/main/java/com/github/se/studentconnect/ui/profile/JoinedEventsViewModel.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/profile/JoinedEventsViewModel.kt
@@ -173,8 +173,7 @@ class JoinedEventsViewModel(
             .sortedWith(
                 compareByDescending<Event> { event ->
                       // Pinned events come first (on own profile only)
-                      if (isOwnProfile && currentState.pinnedEventIds.contains(event.uid)) 1
-                      else 0
+                      if (isOwnProfile && currentState.pinnedEventIds.contains(event.uid)) 1 else 0
                     }
                     .thenBy { event ->
                       // Among pinned events, sort by pin order (earlier in list = earlier pinned)

--- a/app/src/main/java/com/github/se/studentconnect/ui/screen/profile/JoinedEventsScreen.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/screen/profile/JoinedEventsScreen.kt
@@ -1,6 +1,5 @@
 package com.github.se.studentconnect.ui.screen.profile
 
-import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn

--- a/app/src/test/java/com/github/se/studentconnect/ui/profile/JoinedEventsViewModelTest.kt
+++ b/app/src/test/java/com/github/se/studentconnect/ui/profile/JoinedEventsViewModelTest.kt
@@ -551,27 +551,35 @@ class JoinedEventsViewModelTest {
     advanceUntilIdle()
 
     // Initially sorted by date (newest first)
-    assert(viewModel.uiState.value.filteredEvents.map { it.uid } == listOf(event3Id, event2Id, event1Id))
+    assert(
+        viewModel.uiState.value.filteredEvents.map { it.uid } ==
+            listOf(event3Id, event2Id, event1Id))
 
     // When - Pin oldest event
     viewModel.togglePinEvent(event1Id, "Max")
     advanceUntilIdle()
 
     // Then - Pinned event moves to top
-    assert(viewModel.uiState.value.filteredEvents.map { it.uid } == listOf(event1Id, event3Id, event2Id))
+    assert(
+        viewModel.uiState.value.filteredEvents.map { it.uid } ==
+            listOf(event1Id, event3Id, event2Id))
 
     // When - Pin middle event
     viewModel.togglePinEvent(event2Id, "Max")
     advanceUntilIdle()
 
     // Then - Both pinned events at top, sorted by pin order (oldest pinned first)
-    assert(viewModel.uiState.value.filteredEvents.map { it.uid } == listOf(event1Id, event2Id, event3Id))
+    assert(
+        viewModel.uiState.value.filteredEvents.map { it.uid } ==
+            listOf(event1Id, event2Id, event3Id))
 
     // When - Unpin first event
     viewModel.togglePinEvent(event1Id, "Max")
     advanceUntilIdle()
 
     // Then - Only event2 pinned at top, rest sorted by date
-    assert(viewModel.uiState.value.filteredEvents.map { it.uid } == listOf(event2Id, event3Id, event1Id))
+    assert(
+        viewModel.uiState.value.filteredEvents.map { it.uid } ==
+            listOf(event2Id, event3Id, event1Id))
   }
 }


### PR DESCRIPTION
## What?

This PR implements a new feature where pinned events automatically move to the top of the user's event list with an animation when pinning or unpinning them from their profile

## Why?

Before when users pin an event, the pinned event would remain in their original position sorted by date. This made it difficult for users to quickly find their most important pinned events, as they could be anywhere throughout the list based on when they have been pinned.
Now it's more easy for them to find their most important events, and it's also easier for them to depinn them

## How?

- Modified applyFilters() to use a composite sorting strategy
- Added smooth animation when an event is pinned or unpinned with .animateItem()
- Added 1 test which verifies that the event moves to the top, pinned events are sorted by date as the list and when unpinned returns to it position

<img width="346" height="739" alt="image" src="https://github.com/user-attachments/assets/c00cc859-f6c3-4424-98e5-fa4302fc7a7d" />

