### PR TITLE
Revert "Put unit tests on blacksmith"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           path: app/build/reports/lint-*
 
   unit-tests:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-gradle


### PR DESCRIPTION
Reverts StudentConnect-SwEnt/StudentConnect#402

Putting unit tests on blacksmith does not fix any problem and is useless.
This will reduce our cost.
