### PR TITLE
Swap font sizes between subtitle and description in EventView

### DIFF
--- a/app/src/main/java/com/github/se/studentconnect/ui/event/EventView.kt
+++ b/app/src/main/java/com/github/se/studentconnect/ui/event/EventView.kt
@@ -627,7 +627,7 @@ private fun EventInfoCardSection(
                     text = event.subtitle,
                     modifier = Modifier.testTag(EventViewTestTags.SUBTITLE_TEXT),
                     style =
-                        MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                        MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
                     color = MaterialTheme.colorScheme.onSurface,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis)
@@ -642,7 +642,7 @@ private fun EventInfoCardSection(
               Text(
                   text = event.description,
                   modifier = Modifier.testTag(EventViewTestTags.DESCRIPTION_TEXT),
-                  style = MaterialTheme.typography.bodyLarge,
+                  style = MaterialTheme.typography.titleMedium,
                   color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f))
 
               HorizontalDivider(


### PR DESCRIPTION
## What?

Swaps the font sizes between the subtitle and description in EventView - subtitle now uses `bodyLarge` while description uses `titleMedium`.

## Why?

Makes the description text more prominent than the subtitle text.

## How?

Updated the `Text` style properties in the `EventInfoCardSection` composable:
- Subtitle: changed from `titleMedium` to `bodyLarge`
- Description: changed from `bodyLarge` to `titleMedium`

Fixes #419 